### PR TITLE
feat: 增加 AI 友好的在线内容质量监控能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ newsnow hackernews --json
 # Include fetch/quality/enhance metadata in JSON mode
 newsnow hackernews --json --meta
 
+# Print AI quality rubric/schema
+newsnow quality-rubric --json
+
+# Append per-item quality signals for AI judge
+newsnow feed --json --meta --quality-signals
+
 # Enhance summary text by fetching article pages
 newsnow thepaper --json --enhance --enhance-limit 5
 ```
@@ -77,6 +83,15 @@ Aggregate multiple sources into one feed.
 newsnow feed
 newsnow feed --profile all --limit 100 --per-source 2
 newsnow feed --json --meta
+newsnow feed --json --meta --quality-signals
+```
+
+### quality-rubric
+
+Return fixed quality rubric and AI decision schema in JSON format.
+
+```bash
+newsnow quality-rubric --json
 ```
 
 ### source fetch
@@ -99,6 +114,7 @@ newsnow linuxdo --json --meta
 
 - `--json` Output JSON
 - `--meta` Include fetch/quality/enhance metadata (JSON mode)
+- `--quality-signals` JSON mode only, append `quality_signals`/`quality_gate_hint`/`quality_reasons` to each item
 - `--raw` Disable dedupe/quality filtering
 - `--enhance` Fetch article pages and enrich `extra.hover`
 - `--enhance-limit <n>` Max items to enhance per source (default: `5`)
@@ -108,6 +124,25 @@ newsnow linuxdo --json --meta
 - `--limit <n>` Max total items in `feed` mode (default: `120`)
 - `--per-source <n>` Max items per source in `feed` mode (default: `8`)
 - `--concurrency <n>` Fetch concurrency in `feed` mode (default: `4`)
+
+## AI Quality Workflow
+
+Use this 4-step protocol when `newsnow` acts as AI content input:
+
+```bash
+# 1) Get fixed rubric and decision schema
+newsnow quality-rubric --json
+
+# 2) Get candidates + quality monitor + per-item signals
+newsnow feed --json --meta --quality-signals
+```
+
+3. AI only evaluates `quality_gate_hint=review` or high-risk items.
+4. AI returns final decision: `reject | downrank | pass`.
+
+Runtime JSON (when `--meta` or `--quality-signals`):
+- Top-level: `quality_schema_version`, `quality_monitor`, `quality_policy`
+- Per-item: `quality_signals`, `quality_gate_hint`, `quality_reasons`
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 A command-line tool to fetch trending news and hot topics from 66 sources across 44 platforms. Built with TypeScript, runs on Bun.
 
+Now includes quality-first defaults:
+- `list` and `feed` default to a curated `high-quality` source profile
+- automatic source fallback for blocked/empty sources
+- optional article summary enhancement (`--enhance`)
+
 Ported from [ourongxing/newsnow](https://github.com/ourongxing/newsnow) server sources.
 
 ## Install
@@ -27,8 +32,17 @@ npx newsnow
 # Show help
 newsnow --help
 
-# List all available sources
+# List sources (default profile: high-quality)
 newsnow list
+
+# List all sources
+newsnow list --profile all
+
+# Aggregate feed from multiple sources (default profile: high-quality)
+newsnow feed
+
+# Aggregate feed from trending profile
+newsnow feed --profile trending
 
 # Fetch news from a source
 newsnow hackernews
@@ -36,9 +50,64 @@ newsnow hackernews
 # Output as JSON (pipeable to jq, etc.)
 newsnow hackernews --json
 
-# List sources as JSON
-newsnow list --json
+# Include fetch/quality/enhance metadata in JSON mode
+newsnow hackernews --json --meta
+
+# Enhance summary text by fetching article pages
+newsnow thepaper --json --enhance --enhance-limit 5
 ```
+
+## Commands
+
+### list
+
+List sources by profile. Default profile is `high-quality`.
+
+```bash
+newsnow list
+newsnow list --profile all
+newsnow list --profile trending --json
+```
+
+### feed
+
+Aggregate multiple sources into one feed.
+
+```bash
+newsnow feed
+newsnow feed --profile all --limit 100 --per-source 2
+newsnow feed --json --meta
+```
+
+### source fetch
+
+Fetch a single source.
+
+```bash
+newsnow hackernews
+newsnow hackernews --json
+newsnow linuxdo --json --meta
+```
+
+## Profiles
+
+- `high-quality` (default): editorial/news-readability oriented sources
+- `trending`: hot-topic/trending style sources
+- `all`: all registered sources
+
+## Common Options
+
+- `--json` Output JSON
+- `--meta` Include fetch/quality/enhance metadata (JSON mode)
+- `--raw` Disable dedupe/quality filtering
+- `--enhance` Fetch article pages and enrich `extra.hover`
+- `--enhance-limit <n>` Max items to enhance per source (default: `5`)
+- `--no-fallback` Disable automatic source fallback
+- `--profile <high-quality|trending|all>` Source profile for `list`/`feed`
+- `--all` Shortcut for `--profile all`
+- `--limit <n>` Max total items in `feed` mode (default: `120`)
+- `--per-source <n>` Max items per source in `feed` mode (default: `8`)
+- `--concurrency <n>` Fetch concurrency in `feed` mode (default: `4`)
 
 ## Sources
 
@@ -102,7 +171,7 @@ Some sources may be blocked by Cloudflare or require authentication:
 ## Testing
 
 ```bash
-bun test
+bun run test
 ```
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "bun src/cli.ts",
-    "test": "bun test",
+    "test": "bun test test/*.test.ts",
     "build": "tsc",
     "release": "bun run build && npm publish"
   },

--- a/skills/newsnow/SKILL.md
+++ b/skills/newsnow/SKILL.md
@@ -29,6 +29,7 @@ Follow this pattern:
 2. **List or Feed** - Use `list` to inspect source names, or `feed` to aggregate many sources.
 3. **Source Fetch** - If you need one source only, call `newsnow <source>`.
 4. **Diagnostics / Enrichment** - Use `--meta` for health/quality diagnostics; use `--enhance` for summary enrichment.
+5. **AI Quality Signals** - Use `quality-rubric --json` + `--quality-signals` to feed AI judge inputs.
 
 | Need | Command | When |
 |---|---|---|
@@ -37,6 +38,8 @@ Follow this pattern:
 | Aggregate default feed | `newsnow feed` | Want multi-source readable feed |
 | Aggregate trending feed | `newsnow feed --profile trending` | Want hot-topic stream |
 | See feed diagnostics | `newsnow feed --json --meta` | Need fallback/quality stats |
+| Get AI quality rubric | `newsnow quality-rubric --json` | Need fixed LLM decision rubric/schema |
+| Get AI-ready feed signals | `newsnow feed --json --meta --quality-signals` | Need per-item quality signals + run monitor |
 | Get news | `newsnow <source>` | Know the source, want readable output |
 | Get news as JSON | `newsnow <source> --json` | Need structured data for processing |
 | Enrich summary text | `newsnow <source> --json --enhance --enhance-limit 5` | Need better `extra.hover` coverage |
@@ -62,6 +65,13 @@ newsnow feed
 newsnow feed --profile trending
 newsnow feed --profile all --limit 100 --per-source 2
 newsnow feed --json --meta
+newsnow feed --json --meta --quality-signals
+```
+
+### quality-rubric
+
+```bash
+newsnow quality-rubric --json
 ```
 
 ### Fetch a source
@@ -84,6 +94,14 @@ When `--meta` is enabled (JSON mode), output wraps `items` with diagnostics:
 - `sourceUsed`, `fallbackUsed`, `health`, `attempts`
 - `quality` stats (dedupe/filter counts)
 - `enhance` stats when `--enhance` is enabled
+- `quality_schema_version`, `quality_monitor`, `quality_policy`
+
+When `--quality-signals` is enabled (JSON mode), each item adds:
+- `quality_signals`
+- `quality_gate_hint` (`reject|review|pass`)
+- `quality_reasons`
+
+AI final decision enum (outside CLI): `reject|downrank|pass`
 
 ## Sources
 

--- a/skills/newsnow/SKILL.md
+++ b/skills/newsnow/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: newsnow
 description: |
-  CLI tool to fetch trending news and hot topics from 66 sources across 44 platforms. Returns structured news items with titles, URLs, and metadata.
+  CLI tool to fetch trending news and hot topics from 66 sources across 44 platforms. Returns structured news items with titles, URLs, metadata, and optional health/enhancement diagnostics.
 
   USE FOR:
-  - Fetching trending/hot news from Chinese and international platforms
+  - Fetching high-quality news feeds and trending/hot topics
   - Monitoring hot topics across social media, tech, finance, and news sites
-  - Getting structured news data as JSON for further processing
-  - Listing available news sources
+  - Getting structured feed data as JSON for further processing
+  - Listing sources by profile (`high-quality`, `trending`, `all`)
 
-  Requires npm install. Some sources need env vars (PRODUCTHUNT_API_TOKEN). Some sources may be blocked by Cloudflare (linuxdo).
+  Requires npm install. Some sources need env vars (PRODUCTHUNT_API_TOKEN). Some sources may be blocked by Cloudflare (linuxdo), but CLI supports automatic fallback by default.
 allowed-tools:
   - Bash(newsnow *)
   - Bash(npx newsnow *)
@@ -25,26 +25,43 @@ Run `newsnow --help` for usage details.
 
 Follow this pattern:
 
-1. **List** - Don't know what sources are available? List them first.
-2. **Fetch** - Know the source? Fetch news directly.
-3. **JSON** - Need structured data? Add `--json` for machine-readable output.
+1. **Profile** - Pick a source profile (`high-quality` default, `trending`, or `all`).
+2. **List or Feed** - Use `list` to inspect source names, or `feed` to aggregate many sources.
+3. **Source Fetch** - If you need one source only, call `newsnow <source>`.
+4. **Diagnostics / Enrichment** - Use `--meta` for health/quality diagnostics; use `--enhance` for summary enrichment.
 
 | Need | Command | When |
 |---|---|---|
-| See all sources | `newsnow list` | Don't know source names |
-| See sources as JSON | `newsnow list --json` | Need source list programmatically |
+| See default high-quality sources | `newsnow list` | Quick source discovery |
+| See all sources | `newsnow list --profile all` | Need full registry |
+| Aggregate default feed | `newsnow feed` | Want multi-source readable feed |
+| Aggregate trending feed | `newsnow feed --profile trending` | Want hot-topic stream |
+| See feed diagnostics | `newsnow feed --json --meta` | Need fallback/quality stats |
 | Get news | `newsnow <source>` | Know the source, want readable output |
 | Get news as JSON | `newsnow <source> --json` | Need structured data for processing |
+| Enrich summary text | `newsnow <source> --json --enhance --enhance-limit 5` | Need better `extra.hover` coverage |
 
 ## Commands
 
 ### list
 
-List all available sources.
+List sources by profile.
 
 ```bash
 newsnow list
+newsnow list --profile all
 newsnow list --json
+```
+
+### feed
+
+Aggregate multiple sources into one feed.
+
+```bash
+newsnow feed
+newsnow feed --profile trending
+newsnow feed --profile all --limit 100 --per-source 2
+newsnow feed --json --meta
 ```
 
 ### Fetch a source
@@ -52,6 +69,8 @@ newsnow list --json
 ```bash
 newsnow hackernews
 newsnow hackernews --json
+newsnow linuxdo --json --meta
+newsnow thepaper --json --enhance --enhance-limit 5
 ```
 
 Output fields (JSON mode):
@@ -60,6 +79,11 @@ Output fields (JSON mode):
 - `url` - Link to the article (optional)
 - `pubDate` - Publication date (optional)
 - `extra` - Additional metadata like view counts, comments (optional)
+
+When `--meta` is enabled (JSON mode), output wraps `items` with diagnostics:
+- `sourceUsed`, `fallbackUsed`, `health`, `attempts`
+- `quality` stats (dedupe/filter counts)
+- `enhance` stats when `--enhance` is enabled
 
 ## Sources
 
@@ -138,4 +162,6 @@ Output fields (JSON mode):
 newsnow hackernews --json | jq '.[].title'
 newsnow hackernews --json | jq '.[:5]'
 newsnow weibo --json | jq '.[] | "\(.title) \(.url)"'
+newsnow feed --json --meta | jq '.reports'
+newsnow feed --profile high-quality --json | jq '.[:10]'
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,44 +1,193 @@
 #!/usr/bin/env bun
+import { enhanceNewsItems, type EnhanceStats } from "./enhance.js"
+import { normalizeNewsItems, type QualityStats } from "./quality.js"
 import { sources } from "./sources/index.js"
+import { getSourcesByProfile, isSourceProfile, type SourceProfile } from "./source-profiles.js"
+import { fetchWithFallback } from "./source-health.js"
+import type { NewsItem } from "./types.js"
 
-const args = process.argv.slice(2)
-const jsonFlag = args.includes("--json")
-const filteredArgs = args.filter(a => a !== "--json")
-const command = filteredArgs[0]
+interface ParsedCliArgs {
+  command?: string
+  json: boolean
+  raw: boolean
+  meta: boolean
+  enhance: boolean
+  enhanceLimit: number
+  noFallback: boolean
+  profile: SourceProfile
+  feedLimit: number
+  perSource: number
+  feedConcurrency: number
+}
+
+interface ProcessedSourceResult {
+  requestedSource: string
+  usedSource: string
+  fallbackUsed: boolean
+  health: {
+    status: "healthy" | "degraded" | "failed"
+    score: number
+    reason: string
+  }
+  attempts: any[]
+  quality: QualityStats
+  enhance?: EnhanceStats
+  items: NewsItem[]
+}
+
+interface FeedSourceReport {
+  source: string
+  sourceUsed?: string
+  fallbackUsed?: boolean
+  status: "ok" | "failed"
+  health?: string
+  itemCount: number
+  error?: string
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.floor(n)
+}
+
+function parseCliArgs(argv: string[]): ParsedCliArgs {
+  let json = false
+  let raw = false
+  let meta = false
+  let enhance = false
+  let noFallback = false
+  let enhanceLimit = 5
+  let profile: SourceProfile = "high-quality"
+  let feedLimit = 120
+  let perSource = 8
+  let feedConcurrency = 4
+  const positional: string[] = []
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === "--json") {
+      json = true
+      continue
+    }
+    if (arg === "--raw") {
+      raw = true
+      continue
+    }
+    if (arg === "--meta") {
+      meta = true
+      continue
+    }
+    if (arg === "--enhance") {
+      enhance = true
+      continue
+    }
+    if (arg === "--no-fallback") {
+      noFallback = true
+      continue
+    }
+    if (arg === "--all") {
+      profile = "all"
+      continue
+    }
+    if (arg === "--enhance-limit") {
+      enhanceLimit = parsePositiveInt(argv[i + 1], enhanceLimit)
+      i++
+      continue
+    }
+    if (arg === "--profile") {
+      const p = argv[i + 1] || ""
+      if (isSourceProfile(p)) profile = p
+      i++
+      continue
+    }
+    if (arg === "--limit") {
+      feedLimit = parsePositiveInt(argv[i + 1], feedLimit)
+      i++
+      continue
+    }
+    if (arg === "--per-source") {
+      perSource = parsePositiveInt(argv[i + 1], perSource)
+      i++
+      continue
+    }
+    if (arg === "--concurrency") {
+      feedConcurrency = parsePositiveInt(argv[i + 1], feedConcurrency)
+      i++
+      continue
+    }
+    positional.push(arg)
+  }
+
+  return {
+    command: positional[0],
+    json,
+    raw,
+    meta,
+    enhance,
+    enhanceLimit,
+    noFallback,
+    profile,
+    feedLimit,
+    perSource,
+    feedConcurrency,
+  }
+}
+
+const parsedArgs = parseCliArgs(process.argv.slice(2))
+const command = parsedArgs.command
 
 function printHelp() {
   console.log(`Usage: newsnow <source> [--json]
-       newsnow list [--json]
+       newsnow list [--json] [--profile high-quality|trending|all]
+       newsnow feed [--json] [--profile high-quality|trending|all]
 
 Commands:
-  list          List all available sources
-  <source>      Fetch news from the given source
+  list          List available sources (default profile: high-quality)
+  feed          Aggregate multiple sources into one feed (default profile: high-quality)
+  <source>      Fetch news from a single source
 
 Options:
   --json        Output as JSON
+  --meta        JSON mode only, include fetch/quality/enhance metadata
+  --raw         Disable dedupe/quality filtering
+  --enhance     Fetch article pages and enrich summary text (extra.hover)
+  --enhance-limit <n>  Max items to enhance per source (default: 5)
+  --no-fallback Disable automatic source fallback when source fails/empty
+  --profile <name>  Source profile for list/feed: high-quality|trending|all
+  --all         Shortcut for --profile all
+  --limit <n>   Max total items in feed mode (default: 120)
+  --per-source <n>  Max items kept per source in feed mode (default: 8)
+  --concurrency <n> Feed fetch concurrency (default: 4)
 
-Sources: ${Object.keys(sources).length} available. Run "newsnow list" to see all.`)
+Total sources: ${Object.keys(sources).length}.`)
 }
 
 function printList() {
-  const names = Object.keys(sources).sort()
-  if (jsonFlag) {
+  const allNames = Object.keys(sources).sort()
+  const names = getSourcesByProfile(parsedArgs.profile, allNames)
+  if (parsedArgs.json) {
     console.log(JSON.stringify(names, null, 2))
-  } else {
-    console.log(`Available sources (${names.length}):\n`)
-    const groups: Record<string, string[]> = {}
-    for (const name of names) {
-      const base = name.split("-")[0]
-      if (!groups[base]) groups[base] = []
-      groups[base].push(name)
+    return
+  }
+
+  console.log(`Available sources (${names.length}) [profile: ${parsedArgs.profile}]:\n`)
+  const groups: Record<string, string[]> = {}
+  for (const name of names) {
+    const base = name.split("-")[0]
+    if (!groups[base]) groups[base] = []
+    groups[base].push(name)
+  }
+  for (const [base, items] of Object.entries(groups).sort(([a], [b]) => a.localeCompare(b))) {
+    if (items.length === 1) {
+      console.log(`  ${items[0]}`)
+    } else {
+      console.log(`  ${base}: ${items.join(", ")}`)
     }
-    for (const [base, items] of Object.entries(groups).sort(([a], [b]) => a.localeCompare(b))) {
-      if (items.length === 1) {
-        console.log(`  ${items[0]}`)
-      } else {
-        console.log(`  ${base}: ${items.join(", ")}`)
-      }
-    }
+  }
+
+  if (parsedArgs.profile !== "all") {
+    console.log(`\nUse "--profile all" to view all ${allNames.length} sources.`)
   }
 }
 
@@ -64,33 +213,130 @@ function levenshtein(a: string, b: string): number {
   return dp[m][n]
 }
 
+function toTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const asNum = Number(value)
+    if (Number.isFinite(asNum) && asNum > 0) return asNum
+    const parsed = Date.parse(value)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return undefined
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const result: R[] = new Array(items.length)
+  let cursor = 0
+
+  const worker = async () => {
+    while (cursor < items.length) {
+      const idx = cursor++
+      result[idx] = await fn(items[idx], idx)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    () => worker(),
+  )
+  await Promise.all(workers)
+  return result
+}
+
+async function fetchProcessedSource(name: string): Promise<ProcessedSourceResult> {
+  const fetched = await fetchWithFallback(name, sources, {
+    enableFallback: !parsedArgs.noFallback,
+  })
+
+  const { items: normalizedItems, stats: qualityStats } = normalizeNewsItems(fetched.items, {
+    enableDedupe: !parsedArgs.raw,
+    enableQualityFilter: !parsedArgs.raw,
+  })
+
+  let items = normalizedItems
+  let enhanceStats: EnhanceStats | undefined
+  if (parsedArgs.enhance) {
+    const enhanced = await enhanceNewsItems(items, {
+      limit: parsedArgs.enhanceLimit,
+    })
+    items = enhanced.items
+    enhanceStats = enhanced.stats
+  }
+
+  return {
+    requestedSource: fetched.requestedSource,
+    usedSource: fetched.usedSource,
+    fallbackUsed: fetched.fallbackUsed,
+    health: fetched.health,
+    attempts: fetched.attempts,
+    quality: qualityStats,
+    enhance: enhanceStats,
+    items,
+  }
+}
+
 async function fetchSource(name: string) {
   const handler = sources[name]
   if (!handler) {
     const similar = suggestSimilar(name)
     console.error(`Error: Unknown source "${name}"`)
-    if (similar.length) {
-      console.error(`Did you mean: ${similar.join(", ")}?`)
-    }
+    if (similar.length) console.error(`Did you mean: ${similar.join(", ")}?`)
     process.exit(1)
   }
 
   try {
-    const items = await handler()
-    if (jsonFlag) {
-      console.log(JSON.stringify(items, null, 2))
-    } else {
-      if (!items.length) {
-        console.log("No items found.")
-        return
+    const result = await fetchProcessedSource(name)
+    if (!parsedArgs.json && result.quality.nonArrayInput) {
+      console.error(`Warning: source "${result.usedSource}" returned a non-array payload; treated as empty list.`)
+    }
+
+    if (parsedArgs.json) {
+      if (parsedArgs.meta) {
+        console.log(JSON.stringify({
+          source: result.requestedSource,
+          sourceUsed: result.usedSource,
+          fallbackUsed: result.fallbackUsed,
+          health: result.health,
+          attempts: result.attempts,
+          quality: result.quality,
+          enhance: result.enhance,
+          items: result.items,
+        }, null, 2))
+      } else {
+        console.log(JSON.stringify(result.items, null, 2))
       }
-      console.log(`\n${name} (${items.length} items)\n${"─".repeat(60)}`)
-      for (const [i, item] of items.entries()) {
-        const parts = [`${String(i + 1).padStart(3)}. ${item.title}`]
-        if (item.url) parts.push(`     ${item.url}`)
-        if (item.extra?.info && typeof item.extra.info === "string") parts.push(`     ${item.extra.info}`)
-        console.log(parts.join("\n"))
-      }
+      return
+    }
+
+    if (!result.items.length) {
+      console.log("No items found.")
+      return
+    }
+
+    const sourceLabel = result.fallbackUsed
+      ? `${result.requestedSource} -> ${result.usedSource}`
+      : result.usedSource
+    console.log(`\n${sourceLabel} (${result.items.length} items)\n${"─".repeat(60)}`)
+    for (const [i, item] of result.items.entries()) {
+      const parts = [`${String(i + 1).padStart(3)}. ${item.title}`]
+      if (item.url) parts.push(`     ${item.url}`)
+      if (item.extra?.info && typeof item.extra.info === "string") parts.push(`     ${item.extra.info}`)
+      console.log(parts.join("\n"))
+    }
+
+    if (result.health.status !== "healthy") {
+      console.log(`\nSource health: ${result.health.status} (score ${result.health.score}) - ${result.health.reason}`)
+    }
+    if (!parsedArgs.raw && (result.quality.droppedDuplicate || result.quality.droppedLowQuality || result.quality.droppedInvalid)) {
+      const filtered = result.quality.droppedDuplicate + result.quality.droppedLowQuality + result.quality.droppedInvalid
+      console.log(`\nFiltered ${filtered} item(s): ${result.quality.droppedDuplicate} duplicate, ${result.quality.droppedLowQuality} low-quality, ${result.quality.droppedInvalid} invalid.`)
+    }
+    if (parsedArgs.enhance && result.enhance) {
+      console.log(`\nEnhanced ${result.enhance.enhanced}/${result.enhance.attempted} item(s), failed ${result.enhance.failed}, skipped ${result.enhance.skipped}.`)
     }
   } catch (err: any) {
     console.error(`Error fetching "${name}": ${err.message}`)
@@ -98,10 +344,105 @@ async function fetchSource(name: string) {
   }
 }
 
+async function fetchFeed() {
+  const allNames = Object.keys(sources).sort()
+  const profileSources = getSourcesByProfile(parsedArgs.profile, allNames)
+  if (!profileSources.length) {
+    console.error(`Error: profile "${parsedArgs.profile}" has no available sources.`)
+    process.exit(1)
+  }
+
+  const settled = await mapLimit(profileSources, parsedArgs.feedConcurrency, async (name) => {
+    try {
+      const result = await fetchProcessedSource(name)
+      return { name, result }
+    } catch (error: any) {
+      return { name, error: String(error?.message || error) }
+    }
+  })
+
+  const reports: FeedSourceReport[] = []
+  const collected: NewsItem[] = []
+  for (const item of settled) {
+    if ("error" in item) {
+      reports.push({
+        source: item.name,
+        status: "failed",
+        itemCount: 0,
+        error: item.error,
+      })
+      continue
+    }
+
+    const result = item.result
+    const picked = result.items.slice(0, parsedArgs.perSource).map(news => ({
+      ...news,
+      extra: {
+        ...(news.extra || {}),
+        source: result.usedSource,
+        requestedSource: result.requestedSource,
+      },
+    }))
+    collected.push(...picked)
+    reports.push({
+      source: result.requestedSource,
+      sourceUsed: result.usedSource,
+      fallbackUsed: result.fallbackUsed,
+      status: "ok",
+      health: `${result.health.status}:${result.health.score}`,
+      itemCount: picked.length,
+    })
+  }
+
+  const merged = normalizeNewsItems(collected, {
+    enableDedupe: !parsedArgs.raw,
+    enableQualityFilter: !parsedArgs.raw,
+  })
+
+  const sorted = [...merged.items].sort((a, b) => {
+    const ta = toTimestamp(a.pubDate ?? a.extra?.date) ?? 0
+    const tb = toTimestamp(b.pubDate ?? b.extra?.date) ?? 0
+    return tb - ta
+  })
+  const items = sorted.slice(0, parsedArgs.feedLimit)
+
+  if (parsedArgs.json) {
+    if (parsedArgs.meta) {
+      console.log(JSON.stringify({
+        mode: "feed",
+        profile: parsedArgs.profile,
+        requestedSourceCount: profileSources.length,
+        reports,
+        quality: merged.stats,
+        items,
+      }, null, 2))
+    } else {
+      console.log(JSON.stringify(items, null, 2))
+    }
+    return
+  }
+
+  if (!items.length) {
+    console.log("No items found.")
+    return
+  }
+
+  console.log(`\nfeed:${parsedArgs.profile} (${items.length} items)\n${"─".repeat(60)}`)
+  for (const [i, item] of items.entries()) {
+    const src = typeof item.extra?.source === "string" ? `[${item.extra.source}] ` : ""
+    const parts = [`${String(i + 1).padStart(3)}. ${src}${item.title}`]
+    if (item.url) parts.push(`     ${item.url}`)
+    if (item.extra?.info && typeof item.extra.info === "string") parts.push(`     ${item.extra.info}`)
+    console.log(parts.join("\n"))
+  }
+}
+
 if (!command || command === "help" || command === "--help" || command === "-h") {
   printHelp()
 } else if (command === "list") {
   printList()
+} else if (command === "feed") {
+  fetchFeed()
 } else {
   fetchSource(command)
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,9 +45,19 @@ interface FeedSourceReport {
   error?: string
 }
 
-function parsePositiveInt(raw: string | undefined, fallback: number): number {
-  const n = Number(raw)
-  if (!Number.isFinite(n) || n <= 0) return fallback
+function requireOptionValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`)
+  }
+  return value
+}
+
+function parsePositiveIntStrict(value: string, flag: string): number {
+  const n = Number(value)
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`Invalid value for ${flag}: ${value}`)
+  }
   return Math.floor(n)
 }
 
@@ -91,28 +101,35 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
       continue
     }
     if (arg === "--enhance-limit") {
-      enhanceLimit = parsePositiveInt(argv[i + 1], enhanceLimit)
+      const value = requireOptionValue(argv, i, "--enhance-limit")
+      enhanceLimit = parsePositiveIntStrict(value, "--enhance-limit")
       i++
       continue
     }
     if (arg === "--profile") {
-      const p = argv[i + 1] || ""
-      if (isSourceProfile(p)) profile = p
+      const p = requireOptionValue(argv, i, "--profile")
+      if (!isSourceProfile(p)) {
+        throw new Error(`Invalid value for --profile: ${p}`)
+      }
+      profile = p
       i++
       continue
     }
     if (arg === "--limit") {
-      feedLimit = parsePositiveInt(argv[i + 1], feedLimit)
+      const value = requireOptionValue(argv, i, "--limit")
+      feedLimit = parsePositiveIntStrict(value, "--limit")
       i++
       continue
     }
     if (arg === "--per-source") {
-      perSource = parsePositiveInt(argv[i + 1], perSource)
+      const value = requireOptionValue(argv, i, "--per-source")
+      perSource = parsePositiveIntStrict(value, "--per-source")
       i++
       continue
     }
     if (arg === "--concurrency") {
-      feedConcurrency = parsePositiveInt(argv[i + 1], feedConcurrency)
+      const value = requireOptionValue(argv, i, "--concurrency")
+      feedConcurrency = parsePositiveIntStrict(value, "--concurrency")
       i++
       continue
     }
@@ -134,7 +151,13 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
   }
 }
 
-const parsedArgs = parseCliArgs(process.argv.slice(2))
+let parsedArgs: ParsedCliArgs
+try {
+  parsedArgs = parseCliArgs(process.argv.slice(2))
+} catch (error: any) {
+  console.error(`Error: ${String(error?.message || error)}`)
+  process.exit(1)
+}
 const command = parsedArgs.command
 
 function printHelp() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,23 @@
 #!/usr/bin/env bun
 import { enhanceNewsItems, type EnhanceStats } from "./enhance.js"
-import { normalizeNewsItems, type QualityStats } from "./quality.js"
+import {
+  evaluateQualityForItems,
+  getQualityRubric,
+  normalizeNewsItems,
+  QUALITY_POLICY,
+  QUALITY_SCHEMA_VERSION,
+  summarizeQualityBySource,
+  type PerSourceQualityStats,
+  type QualityGateStats,
+  type QualityStats,
+} from "./quality.js"
 import { sources } from "./sources/index.js"
 import { getSourcesByProfile, isSourceProfile, type SourceProfile } from "./source-profiles.js"
-import { fetchWithFallback } from "./source-health.js"
+import {
+  buildSourceQualityContext,
+  fetchWithFallback,
+  type SourceQualityContext,
+} from "./source-health.js"
 import type { NewsItem } from "./types.js"
 
 interface ParsedCliArgs {
@@ -11,6 +25,7 @@ interface ParsedCliArgs {
   json: boolean
   raw: boolean
   meta: boolean
+  qualitySignals: boolean
   enhance: boolean
   enhanceLimit: number
   noFallback: boolean
@@ -31,6 +46,9 @@ interface ProcessedSourceResult {
   }
   attempts: any[]
   quality: QualityStats
+  qualityGate: QualityGateStats
+  qualityBySource: PerSourceQualityStats
+  sourceQualityContext: SourceQualityContext
   enhance?: EnhanceStats
   items: NewsItem[]
 }
@@ -43,6 +61,27 @@ interface FeedSourceReport {
   health?: string
   itemCount: number
   error?: string
+}
+
+interface QualityMonitorSource {
+  source: string
+  source_used?: string
+  item_count: number
+  rule_reject_rate: number
+  health_status: "healthy" | "degraded" | "failed"
+  fallback_used: boolean
+}
+
+interface QualityMonitor {
+  total_items: number
+  rule_reject_count: number
+  review_count: number
+  pass_count: number
+  degraded_source_count: number
+  fallback_source_count: number
+  avg_source_health_score: number
+  sources: QualityMonitorSource[]
+  quality_alerts: string[]
 }
 
 function requireOptionValue(argv: string[], index: number, flag: string): string {
@@ -65,6 +104,7 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
   let json = false
   let raw = false
   let meta = false
+  let qualitySignals = false
   let enhance = false
   let noFallback = false
   let enhanceLimit = 5
@@ -86,6 +126,10 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
     }
     if (arg === "--meta") {
       meta = true
+      continue
+    }
+    if (arg === "--quality-signals") {
+      qualitySignals = true
       continue
     }
     if (arg === "--enhance") {
@@ -141,6 +185,7 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
     json,
     raw,
     meta,
+    qualitySignals,
     enhance,
     enhanceLimit,
     noFallback,
@@ -164,15 +209,18 @@ function printHelp() {
   console.log(`Usage: newsnow <source> [--json]
        newsnow list [--json] [--profile high-quality|trending|all]
        newsnow feed [--json] [--profile high-quality|trending|all]
+       newsnow quality-rubric --json
 
 Commands:
   list          List available sources (default profile: high-quality)
   feed          Aggregate multiple sources into one feed (default profile: high-quality)
+  quality-rubric  Print fixed quality rubric/schema for AI judges
   <source>      Fetch news from a single source
 
 Options:
   --json        Output as JSON
   --meta        JSON mode only, include fetch/quality/enhance metadata
+  --quality-signals JSON mode only, append quality_signals/gate fields to each item
   --raw         Disable dedupe/quality filtering
   --enhance     Fetch article pages and enrich summary text (extra.hover)
   --enhance-limit <n>  Max items to enhance per source (default: 5)
@@ -212,6 +260,11 @@ function printList() {
   if (parsedArgs.profile !== "all") {
     console.log(`\nUse "--profile all" to view all ${allNames.length} sources.`)
   }
+}
+
+function printQualityRubric() {
+  const rubric = getQualityRubric()
+  console.log(JSON.stringify(rubric, null, 2))
 }
 
 function suggestSimilar(input: string): string[] {
@@ -270,7 +323,70 @@ async function mapLimit<T, R>(
   return result
 }
 
-async function fetchProcessedSource(name: string): Promise<ProcessedSourceResult> {
+function toRate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0
+  return Math.round((numerator / denominator) * 10000) / 10000
+}
+
+function aggregateSourceMonitor(result: ProcessedSourceResult): {
+  source: QualityMonitorSource
+  totalItems: number
+  ruleRejectCount: number
+  reviewCount: number
+  passCount: number
+  healthScore: number
+} {
+  const totalItems = result.quality.inputCount + (result.quality.nonArrayInput ? 1 : 0)
+  const ruleRejectCount = result.quality.droppedInvalid
+    + result.quality.droppedLowQuality
+    + result.qualityGate.rule_reject_count
+    + (result.quality.nonArrayInput ? 1 : 0)
+
+  return {
+    source: {
+      source: result.requestedSource,
+      source_used: result.usedSource,
+      item_count: totalItems,
+      rule_reject_rate: toRate(ruleRejectCount, Math.max(1, totalItems)),
+      health_status: result.sourceQualityContext.health_status,
+      fallback_used: result.fallbackUsed,
+    },
+    totalItems,
+    ruleRejectCount,
+    reviewCount: result.qualityGate.review_count,
+    passCount: result.qualityGate.pass_count,
+    healthScore: result.sourceQualityContext.source_health_score,
+  }
+}
+
+function buildQualityAlerts(monitor: QualityMonitor): string[] {
+  const alerts: string[] = []
+  const rejectRate = toRate(monitor.rule_reject_count, Math.max(1, monitor.total_items))
+  if (monitor.degraded_source_count > 0) {
+    alerts.push(`degraded_source_count:${monitor.degraded_source_count}`)
+  }
+  if (monitor.fallback_source_count > 0) {
+    alerts.push(`fallback_source_count:${monitor.fallback_source_count}`)
+  }
+  if (rejectRate >= 0.3) {
+    alerts.push(`high_rule_reject_rate:${rejectRate}`)
+  }
+  const badSources = monitor.sources
+    .filter(item => item.rule_reject_rate >= 0.4)
+    .map(item => `${item.source}:${item.rule_reject_rate}`)
+  if (badSources.length) {
+    alerts.push(`source_reject_rate_spike:${badSources.join(",")}`)
+  }
+  return alerts
+}
+
+async function fetchProcessedSource(
+  name: string,
+  options: {
+    sourceProfile: string
+    attachSignals: boolean
+  },
+): Promise<ProcessedSourceResult> {
   const fetched = await fetchWithFallback(name, sources, {
     enableFallback: !parsedArgs.noFallback,
   })
@@ -290,6 +406,28 @@ async function fetchProcessedSource(name: string): Promise<ProcessedSourceResult
     enhanceStats = enhanced.stats
   }
 
+  const sourceQualityContext = buildSourceQualityContext(
+    fetched.health,
+    fetched.attempts,
+    fetched.fallbackUsed,
+  )
+  const qualityEvaluated = evaluateQualityForItems(items, {
+    sourceProfile: options.sourceProfile,
+    sourceContexts: {
+      [fetched.usedSource]: sourceQualityContext,
+    },
+    defaultSource: fetched.usedSource,
+    attachSignals: options.attachSignals,
+    enableHardReject: !parsedArgs.raw,
+  })
+  items = qualityEvaluated.items
+  const qualityBySource = summarizeQualityBySource(qualityEvaluated.evaluations)[fetched.usedSource] || {
+    total_items: 0,
+    rule_reject_count: 0,
+    review_count: 0,
+    pass_count: 0,
+  }
+
   return {
     requestedSource: fetched.requestedSource,
     usedSource: fetched.usedSource,
@@ -297,6 +435,9 @@ async function fetchProcessedSource(name: string): Promise<ProcessedSourceResult
     health: fetched.health,
     attempts: fetched.attempts,
     quality: qualityStats,
+    qualityGate: qualityEvaluated.stats,
+    qualityBySource,
+    sourceQualityContext,
     enhance: enhanceStats,
     items,
   }
@@ -312,26 +453,51 @@ async function fetchSource(name: string) {
   }
 
   try {
-    const result = await fetchProcessedSource(name)
+    const result = await fetchProcessedSource(name, {
+      sourceProfile: "single-source",
+      attachSignals: parsedArgs.json && parsedArgs.qualitySignals,
+    })
     if (!parsedArgs.json && result.quality.nonArrayInput) {
       console.error(`Warning: source "${result.usedSource}" returned a non-array payload; treated as empty list.`)
     }
 
+    const sourceAgg = aggregateSourceMonitor(result)
+    const qualityMonitor: QualityMonitor = {
+      total_items: sourceAgg.totalItems,
+      rule_reject_count: sourceAgg.ruleRejectCount,
+      review_count: sourceAgg.reviewCount,
+      pass_count: sourceAgg.passCount,
+      degraded_source_count: sourceAgg.source.health_status === "healthy" ? 0 : 1,
+      fallback_source_count: result.fallbackUsed ? 1 : 0,
+      avg_source_health_score: sourceAgg.healthScore,
+      sources: [sourceAgg.source],
+      quality_alerts: [],
+    }
+    qualityMonitor.quality_alerts = buildQualityAlerts(qualityMonitor)
+
     if (parsedArgs.json) {
-      if (parsedArgs.meta) {
-        console.log(JSON.stringify({
-          source: result.requestedSource,
-          sourceUsed: result.usedSource,
-          fallbackUsed: result.fallbackUsed,
-          health: result.health,
-          attempts: result.attempts,
-          quality: result.quality,
-          enhance: result.enhance,
-          items: result.items,
-        }, null, 2))
-      } else {
+      const includeQualityEnvelope = parsedArgs.meta || parsedArgs.qualitySignals
+      if (!includeQualityEnvelope) {
         console.log(JSON.stringify(result.items, null, 2))
+        return
       }
+
+      const payload: Record<string, unknown> = {
+        source: result.requestedSource,
+        sourceUsed: result.usedSource,
+        fallbackUsed: result.fallbackUsed,
+        items: result.items,
+        quality_schema_version: QUALITY_SCHEMA_VERSION,
+        quality_monitor: qualityMonitor,
+        quality_policy: QUALITY_POLICY,
+      }
+      if (parsedArgs.meta) {
+        payload.health = result.health
+        payload.attempts = result.attempts
+        payload.quality = result.quality
+        payload.enhance = result.enhance
+      }
+      console.log(JSON.stringify(payload, null, 2))
       return
     }
 
@@ -377,7 +543,10 @@ async function fetchFeed() {
 
   const settled = await mapLimit(profileSources, parsedArgs.feedConcurrency, async (name) => {
     try {
-      const result = await fetchProcessedSource(name)
+      const result = await fetchProcessedSource(name, {
+        sourceProfile: parsedArgs.profile,
+        attachSignals: false,
+      })
       return { name, result }
     } catch (error: any) {
       return { name, error: String(error?.message || error) }
@@ -386,6 +555,11 @@ async function fetchFeed() {
 
   const reports: FeedSourceReport[] = []
   const collected: NewsItem[] = []
+  const sourceContexts: Record<string, SourceQualityContext> = {}
+  const qualitySources: QualityMonitorSource[] = []
+  const healthScores: number[] = []
+  let sourceRuleRejectCount = 0
+  let sourceTotalItems = 0
   for (const item of settled) {
     if ("error" in item) {
       reports.push({
@@ -394,10 +568,20 @@ async function fetchFeed() {
         itemCount: 0,
         error: item.error,
       })
+      qualitySources.push({
+        source: item.name,
+        item_count: 0,
+        rule_reject_rate: 1,
+        health_status: "failed",
+        fallback_used: false,
+      })
+      healthScores.push(0)
       continue
     }
 
     const result = item.result
+    sourceContexts[result.usedSource] = result.sourceQualityContext
+    sourceContexts[result.requestedSource] = result.sourceQualityContext
     const picked = result.items.slice(0, parsedArgs.perSource).map(news => ({
       ...news,
       extra: {
@@ -416,6 +600,12 @@ async function fetchFeed() {
       health: `${result.health.status}:${result.health.score}`,
       itemCount: picked.length,
     })
+
+    const sourceAggregate = aggregateSourceMonitor(result)
+    qualitySources.push(sourceAggregate.source)
+    healthScores.push(sourceAggregate.healthScore)
+    sourceRuleRejectCount += sourceAggregate.ruleRejectCount
+    sourceTotalItems += sourceAggregate.totalItems
   }
 
   const merged = normalizeNewsItems(collected, {
@@ -428,21 +618,61 @@ async function fetchFeed() {
     const tb = toTimestamp(b.pubDate ?? b.extra?.date) ?? 0
     return tb - ta
   })
-  const items = sorted.slice(0, parsedArgs.feedLimit)
+  const feedSliced = sorted.slice(0, parsedArgs.feedLimit)
+  const evaluatedFeed = evaluateQualityForItems(feedSliced, {
+    sourceProfile: parsedArgs.profile,
+    sourceContexts,
+    defaultSource: "feed",
+    attachSignals: parsedArgs.json && parsedArgs.qualitySignals,
+    enableHardReject: !parsedArgs.raw,
+  })
+  const items = evaluatedFeed.items
+
+  const totalItems = sourceTotalItems
+  const ruleRejectCount = sourceRuleRejectCount
+    + merged.stats.droppedInvalid
+    + merged.stats.droppedLowQuality
+    + (merged.stats.nonArrayInput ? 1 : 0)
+    + evaluatedFeed.stats.rule_reject_count
+  const degradedSourceCount = qualitySources.filter(item => item.health_status !== "healthy").length
+  const fallbackSourceCount = qualitySources.filter(item => item.fallback_used).length
+  const avgSourceHealthScore = healthScores.length
+    ? Math.round((healthScores.reduce((sum, n) => sum + n, 0) / healthScores.length) * 100) / 100
+    : 0
+  const qualityMonitor: QualityMonitor = {
+    total_items: totalItems,
+    rule_reject_count: ruleRejectCount,
+    review_count: evaluatedFeed.stats.review_count,
+    pass_count: evaluatedFeed.stats.pass_count,
+    degraded_source_count: degradedSourceCount,
+    fallback_source_count: fallbackSourceCount,
+    avg_source_health_score: avgSourceHealthScore,
+    sources: qualitySources,
+    quality_alerts: [],
+  }
+  qualityMonitor.quality_alerts = buildQualityAlerts(qualityMonitor)
 
   if (parsedArgs.json) {
-    if (parsedArgs.meta) {
-      console.log(JSON.stringify({
-        mode: "feed",
-        profile: parsedArgs.profile,
-        requestedSourceCount: profileSources.length,
-        reports,
-        quality: merged.stats,
-        items,
-      }, null, 2))
-    } else {
+    const includeQualityEnvelope = parsedArgs.meta || parsedArgs.qualitySignals
+    if (!includeQualityEnvelope) {
       console.log(JSON.stringify(items, null, 2))
+      return
     }
+
+    const payload: Record<string, unknown> = {
+      mode: "feed",
+      profile: parsedArgs.profile,
+      requestedSourceCount: profileSources.length,
+      items,
+      quality_schema_version: QUALITY_SCHEMA_VERSION,
+      quality_monitor: qualityMonitor,
+      quality_policy: QUALITY_POLICY,
+    }
+    if (parsedArgs.meta) {
+      payload.reports = reports
+      payload.quality = merged.stats
+    }
+    console.log(JSON.stringify(payload, null, 2))
     return
   }
 
@@ -465,6 +695,8 @@ if (!command || command === "help" || command === "--help" || command === "-h") 
   printHelp()
 } else if (command === "list") {
   printList()
+} else if (command === "quality-rubric") {
+  printQualityRubric()
 } else if (command === "feed") {
   fetchFeed()
 } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -384,11 +384,12 @@ async function fetchFeed() {
       },
     }))
     collected.push(...picked)
+    const status = result.health.status === "failed" || picked.length === 0 ? "failed" : "ok"
     reports.push({
       source: result.requestedSource,
       sourceUsed: result.usedSource,
       fallbackUsed: result.fallbackUsed,
-      status: "ok",
+      status,
       health: `${result.health.status}:${result.health.score}`,
       itemCount: picked.length,
     })

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -1,0 +1,207 @@
+import * as cheerio from "cheerio"
+import { myFetch } from "./fetch.js"
+import type { NewsItem } from "./types.js"
+
+export interface EnhanceOptions {
+  limit?: number
+  concurrency?: number
+}
+
+export interface EnhanceStats {
+  attempted: number
+  enhanced: number
+  failed: number
+  skipped: number
+}
+
+const SKIP_HOSTS = new Set([
+  "s.weibo.com",
+  "top.baidu.com",
+  "search.bilibili.com",
+  "xueqiu.com",
+  "stock.xueqiu.com",
+  "news.ycombinator.com",
+])
+
+const GENERIC_SITE_SUMMARY_PATTERNS = [
+  /新闻网|官网|门户网站/i,
+  /互联网平台|致力于|欢迎访问|权威发布/i,
+  /copyright|all rights reserved/i,
+]
+
+const LOW_VALUE_SUMMARY_PATTERNS = [
+  /ICP备|公网安备|沪ICP/i,
+  /登录|注册|下载\s*app|iPhone版|Android版/i,
+  /隐私政策|用户协议|免责声明/i,
+]
+
+function cleanText(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function truncate(text: string, maxLen = 260): string {
+  if (text.length <= maxLen) return text
+  return `${text.slice(0, maxLen - 1).trimEnd()}…`
+}
+
+function isUsableSummary(text: string): boolean {
+  if (text.length < 24) return false
+  return !LOW_VALUE_SUMMARY_PATTERNS.some(p => p.test(text))
+}
+
+function shouldEnhance(url?: string): boolean {
+  if (!url) return false
+  try {
+    const u = new URL(url)
+    if (!u.protocol.startsWith("http")) return false
+    if (SKIP_HOSTS.has(u.hostname)) return false
+    if (/(^|\/)(search|top|trending)(\/|$)/i.test(u.pathname)) return false
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function extractSummaryFromHtml(html: string): string | undefined {
+  const $ = cheerio.load(html)
+  const metaSummary = cleanText(
+    $("meta[name='description']").attr("content")
+      || $("meta[property='og:description']").attr("content")
+      || $("meta[name='twitter:description']").attr("content")
+      || "",
+  )
+  const genericMeta = GENERIC_SITE_SUMMARY_PATTERNS.some(p => p.test(metaSummary))
+  if (!genericMeta && isUsableSummary(metaSummary)) {
+    return truncate(metaSummary)
+  }
+
+  const selectors = [
+    "article",
+    "main article",
+    ".article-content",
+    ".entry-content",
+    ".post-content",
+    ".content",
+    "main",
+  ]
+
+  for (const sel of selectors) {
+    const text = cleanText(
+      $(sel)
+        .first()
+        .find("p")
+        .slice(0, 6)
+        .toArray()
+        .map(el => $(el).text())
+        .join(" "),
+    )
+    if (isUsableSummary(text)) {
+      return truncate(text)
+    }
+  }
+
+  const fallback = cleanText(
+    $("p")
+      .slice(0, 5)
+      .toArray()
+      .map(el => $(el).text())
+      .join(" "),
+  )
+  if (isUsableSummary(fallback)) {
+    return truncate(fallback)
+  }
+  return undefined
+}
+
+async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const result: R[] = new Array(items.length)
+  let nextIndex = 0
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const idx = nextIndex++
+      result[idx] = await fn(items[idx], idx)
+    }
+  }
+
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, () => worker())
+  await Promise.all(workers)
+  return result
+}
+
+export async function enhanceNewsItems(
+  items: NewsItem[],
+  options: EnhanceOptions = {},
+): Promise<{ items: NewsItem[]; stats: EnhanceStats }> {
+  const limit = Math.max(0, options.limit ?? 5)
+  const concurrency = Math.max(1, options.concurrency ?? 3)
+
+  if (!limit || !items.length) {
+    return {
+      items,
+      stats: { attempted: 0, enhanced: 0, failed: 0, skipped: items.length ? 0 : 0 },
+    }
+  }
+
+  const cloned = items.map(item => ({ ...item, extra: item.extra ? { ...item.extra } : undefined }))
+  const candidateIndexes: number[] = []
+  let skipped = 0
+
+  for (let i = 0; i < cloned.length; i++) {
+    if (candidateIndexes.length >= limit) break
+    const item = cloned[i]
+    const existingHover = typeof item.extra?.hover === "string" ? cleanText(item.extra.hover) : ""
+    if (existingHover.length >= 40) {
+      skipped++
+      continue
+    }
+    if (!shouldEnhance(item.url)) {
+      skipped++
+      continue
+    }
+    candidateIndexes.push(i)
+  }
+
+  let enhanced = 0
+  let failed = 0
+
+  await mapLimit(candidateIndexes, concurrency, async (idx) => {
+    const item = cloned[idx]
+    try {
+      const html = await myFetch<string>(item.url!, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+          "Accept": "text/html,application/xhtml+xml",
+        },
+        responseType: "text",
+      })
+      const summary = extractSummaryFromHtml(html)
+      if (summary) {
+        item.extra = {
+          ...(item.extra || {}),
+          hover: summary,
+          enhanced: true,
+        }
+        enhanced++
+      } else {
+        failed++
+      }
+    } catch {
+      failed++
+    }
+  })
+
+  return {
+    items: cloned,
+    stats: {
+      attempted: candidateIndexes.length,
+      enhanced,
+      failed,
+      skipped,
+    },
+  }
+}

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -140,10 +140,17 @@ export async function enhanceNewsItems(
   const limit = Math.max(0, options.limit ?? 5)
   const concurrency = Math.max(1, options.concurrency ?? 3)
 
-  if (!limit || !items.length) {
+  if (!items.length) {
     return {
       items,
-      stats: { attempted: 0, enhanced: 0, failed: 0, skipped: items.length ? 0 : 0 },
+      stats: { attempted: 0, enhanced: 0, failed: 0, skipped: 0 },
+    }
+  }
+
+  if (!limit) {
+    return {
+      items,
+      stats: { attempted: 0, enhanced: 0, failed: 0, skipped: items.length },
     }
   }
 

--- a/src/quality.ts
+++ b/src/quality.ts
@@ -1,0 +1,131 @@
+import type { NewsItem } from "./types.js"
+
+export interface QualityOptions {
+  enableDedupe?: boolean
+  enableQualityFilter?: boolean
+}
+
+export interface QualityStats {
+  inputCount: number
+  outputCount: number
+  droppedInvalid: number
+  droppedDuplicate: number
+  droppedLowQuality: number
+  nonArrayInput: boolean
+}
+
+const LOW_QUALITY_PATTERNS = [
+  /^(广告|推广|赞助|置顶|热搜|热门|更多|详情|点击查看|查看全文|全文)$/i,
+  /^[-_=|#\s]+$/,
+  /^\d+$/,
+]
+
+function normalizeText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function normalizeTitleKey(title: string): string {
+  return normalizeText(title)
+    .toLowerCase()
+    .replace(/[【】\[\]()（）'"`]/g, "")
+    .replace(/\s+/g, "")
+}
+
+function normalizeUrl(url: string): string {
+  const trimmed = url.trim()
+  try {
+    const u = new URL(trimmed)
+    u.hash = ""
+    return u.toString()
+  } catch {
+    return trimmed
+  }
+}
+
+function isLowQualityTitle(title: string): boolean {
+  const t = normalizeText(title)
+  if (!t) return true
+  if (t.length < 2) return true
+  return LOW_QUALITY_PATTERNS.some(p => p.test(t))
+}
+
+function normalizeItem(item: NewsItem): NewsItem {
+  const title = normalizeText(String(item.title || ""))
+  const url = typeof item.url === "string" ? normalizeUrl(item.url) : undefined
+  const next: NewsItem = {
+    ...item,
+    title,
+    ...(url ? { url } : {}),
+  }
+
+  if (next.extra?.hover && typeof next.extra.hover === "string") {
+    next.extra = {
+      ...next.extra,
+      hover: normalizeText(next.extra.hover),
+    }
+  }
+
+  if (next.id === undefined || next.id === null || String(next.id).trim() === "") {
+    next.id = next.url || title
+  }
+
+  return next
+}
+
+export function normalizeNewsItems(
+  input: unknown,
+  opts: QualityOptions = {},
+): { items: NewsItem[]; stats: QualityStats } {
+  const enableDedupe = opts.enableDedupe !== false
+  const enableQualityFilter = opts.enableQualityFilter !== false
+  const source = Array.isArray(input) ? input : []
+
+  const stats: QualityStats = {
+    inputCount: source.length,
+    outputCount: 0,
+    droppedInvalid: 0,
+    droppedDuplicate: 0,
+    droppedLowQuality: 0,
+    nonArrayInput: !Array.isArray(input),
+  }
+
+  const seenUrl = new Set<string>()
+  const seenTitle = new Set<string>()
+  const items: NewsItem[] = []
+
+  for (const raw of source) {
+    if (!raw || typeof raw !== "object") {
+      stats.droppedInvalid++
+      continue
+    }
+
+    const item = normalizeItem(raw as NewsItem)
+    if (!item.title) {
+      stats.droppedInvalid++
+      continue
+    }
+
+    if (enableQualityFilter && isLowQualityTitle(item.title)) {
+      stats.droppedLowQuality++
+      continue
+    }
+
+    const titleKey = normalizeTitleKey(item.title)
+    const urlKey = item.url ? normalizeUrl(item.url) : ""
+    if (enableDedupe && ((urlKey && seenUrl.has(urlKey)) || seenTitle.has(titleKey))) {
+      stats.droppedDuplicate++
+      continue
+    }
+
+    if (urlKey) seenUrl.add(urlKey)
+    seenTitle.add(titleKey)
+    items.push(item)
+  }
+
+  stats.outputCount = items.length
+  return { items, stats }
+}

--- a/src/quality.ts
+++ b/src/quality.ts
@@ -1,3 +1,4 @@
+import type { SourceQualityContext } from "./source-health.js"
 import type { NewsItem } from "./types.js"
 
 export interface QualityOptions {
@@ -14,10 +15,101 @@ export interface QualityStats {
   nonArrayInput: boolean
 }
 
+export type QualityGateHint = "reject" | "review" | "pass"
+export type TimestampConfidence = "none" | "low" | "medium" | "high"
+
+export interface ItemQualitySignals {
+  title_len: number
+  has_url: boolean
+  has_pubdate: boolean
+  has_hover: boolean
+  hover_len: number
+  id_stable: boolean
+  title_noise_ratio: number
+  hover_noise_ratio: number
+  low_value_pattern_hit: boolean
+  boilerplate_hit: boolean
+  source_health_score: number
+  fallback_used: boolean
+  attempt_error_count: number
+  source_profile: string
+  age_seconds: number | null
+  timestamp_confidence: TimestampConfidence
+  dedupe_hit: boolean
+  canonical_url: string | null
+  cross_source_duplicate_count: number
+}
+
+export interface QualityEvaluation {
+  item: NewsItem
+  source: string
+  quality_signals: ItemQualitySignals
+  quality_gate_hint: QualityGateHint
+  quality_reasons: string[]
+}
+
+export interface QualityGateStats {
+  total_items: number
+  rule_reject_count: number
+  review_count: number
+  pass_count: number
+}
+
+export interface EvaluateQualityOptions {
+  sourceProfile: string
+  sourceContexts?: Record<string, SourceQualityContext>
+  defaultSource?: string
+  attachSignals?: boolean
+  enableHardReject?: boolean
+  nowMs?: number
+}
+
+export interface EvaluateQualityResult {
+  items: NewsItem[]
+  evaluations: QualityEvaluation[]
+  stats: QualityGateStats
+}
+
+export interface PerSourceQualityStats {
+  total_items: number
+  rule_reject_count: number
+  review_count: number
+  pass_count: number
+}
+
+export const QUALITY_SCHEMA_VERSION = "1.0.0"
+
+export const QUALITY_POLICY = {
+  cli_hard_gate: [
+    "empty_title",
+    "title_too_short",
+    "low_value_pattern",
+    "boilerplate_text",
+    "non_array_payload",
+  ],
+  cli_gate_hint_enum: ["reject", "review", "pass"],
+  ai_final_decision_enum: ["reject", "downrank", "pass"],
+  ai_review_scope: "review_only_or_high_risk",
+}
+
 const LOW_QUALITY_PATTERNS = [
   /^(广告|推广|赞助|置顶|热搜|热门|更多|详情|点击查看|查看全文|全文)$/i,
   /^[-_=|#\s]+$/,
   /^\d+$/,
+]
+
+const LOW_VALUE_PATTERNS = [
+  /^(广告|推广|赞助|置顶|热搜|热门|更多|详情|点击查看|查看全文|全文)$/i,
+  /^[-_=|#\s]+$/,
+  /^\d+$/,
+  /^(点击|查看|详情|阅读全文)/i,
+]
+
+const BOILERPLATE_PATTERNS = [
+  /^点击查看/i,
+  /^查看全文/i,
+  /^阅读全文/i,
+  /^via\s+/i,
 ]
 
 function normalizeText(value: string): string {
@@ -35,7 +127,7 @@ function normalizeTitleKey(title: string): string {
     .replace(/\s+/g, "")
 }
 
-function normalizeUrl(url: string): string {
+export function normalizeUrl(url: string): string {
   const trimmed = url.trim()
   try {
     const u = new URL(trimmed)
@@ -128,4 +220,311 @@ export function normalizeNewsItems(
 
   stats.outputCount = items.length
   return { items, stats }
+}
+
+function round(value: number, precision = 4): number {
+  const base = 10 ** precision
+  return Math.round(value * base) / base
+}
+
+function getNoiseRatio(text: string): number {
+  const value = normalizeText(text).replace(/\s+/g, "")
+  if (!value) return 1
+  let noise = 0
+  for (const ch of value) {
+    if (/[\p{L}\p{N}]/u.test(ch)) continue
+    noise++
+  }
+  return round(noise / value.length)
+}
+
+function hasLowValuePattern(text: string): boolean {
+  const value = normalizeText(text)
+  if (!value) return true
+  return LOW_VALUE_PATTERNS.some(p => p.test(value))
+}
+
+function hasBoilerplate(text: string): boolean {
+  const value = normalizeText(text)
+  if (!value) return false
+  return BOILERPLATE_PATTERNS.some(p => p.test(value))
+}
+
+function parseTimestampMs(value: unknown): { tsMs?: number; confidence: TimestampConfidence } {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    const tsMs = value < 1e12 ? value * 1000 : value
+    return { tsMs, confidence: "high" }
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (!trimmed) return { confidence: "none" }
+    const asNum = Number(trimmed)
+    if (Number.isFinite(asNum) && asNum > 0) {
+      const tsMs = asNum < 1e12 ? asNum * 1000 : asNum
+      return { tsMs, confidence: "high" }
+    }
+    const parsed = Date.parse(trimmed)
+    if (!Number.isNaN(parsed)) {
+      return { tsMs: parsed, confidence: "medium" }
+    }
+    return { confidence: "low" }
+  }
+  return { confidence: "none" }
+}
+
+function getCanonicalUrl(item: NewsItem): string | null {
+  if (typeof item.url === "string" && item.url.trim()) return normalizeUrl(item.url)
+  return null
+}
+
+function getCanonicalKey(item: NewsItem): string {
+  const canonicalUrl = getCanonicalUrl(item)
+  if (canonicalUrl) return `url:${canonicalUrl}`
+  return `title:${normalizeTitleKey(item.title || "")}`
+}
+
+function inferSource(item: NewsItem, fallbackSource: string): string {
+  if (typeof item.extra?.requestedSource === "string" && item.extra.requestedSource.trim()) {
+    return item.extra.requestedSource.trim()
+  }
+  if (typeof item.extra?.source === "string" && item.extra.source.trim()) {
+    return item.extra.source.trim()
+  }
+  return fallbackSource
+}
+
+function buildSignals(
+  item: NewsItem,
+  opts: {
+    source: string
+    sourceProfile: string
+    sourceContext: SourceQualityContext
+    canonicalCount: number
+    crossSourceDuplicateCount: number
+    nowMs: number
+  },
+): ItemQualitySignals {
+  const title = normalizeText(item.title || "")
+  const hover = typeof item.extra?.hover === "string" ? normalizeText(item.extra.hover) : ""
+  const canonicalUrl = getCanonicalUrl(item)
+  const pub = parseTimestampMs(item.pubDate ?? item.extra?.date)
+
+  let ageSeconds: number | null = null
+  if (pub.tsMs !== undefined) {
+    ageSeconds = Math.max(0, Math.floor((opts.nowMs - pub.tsMs) / 1000))
+  }
+
+  return {
+    title_len: title.length,
+    has_url: Boolean(canonicalUrl),
+    has_pubdate: pub.tsMs !== undefined,
+    has_hover: Boolean(hover),
+    hover_len: hover.length,
+    id_stable: String(item.id || "").trim() !== "" && String(item.id) !== title,
+    title_noise_ratio: getNoiseRatio(title),
+    hover_noise_ratio: hover ? getNoiseRatio(hover) : 0,
+    low_value_pattern_hit: hasLowValuePattern(title),
+    boilerplate_hit: hasBoilerplate(hover),
+    source_health_score: opts.sourceContext.source_health_score,
+    fallback_used: opts.sourceContext.fallback_used,
+    attempt_error_count: opts.sourceContext.attempt_error_count,
+    source_profile: opts.sourceProfile,
+    age_seconds: ageSeconds,
+    timestamp_confidence: pub.confidence,
+    dedupe_hit: opts.canonicalCount > 1,
+    canonical_url: canonicalUrl,
+    cross_source_duplicate_count: opts.crossSourceDuplicateCount,
+  }
+}
+
+function buildGateHint(signals: ItemQualitySignals): { hint: QualityGateHint; reasons: string[] } {
+  const rejectReasons: string[] = []
+  if (signals.title_len === 0) rejectReasons.push("empty_title")
+  if (signals.title_len > 0 && signals.title_len < 4) rejectReasons.push("title_too_short")
+  if (signals.low_value_pattern_hit) rejectReasons.push("low_value_pattern")
+  if (signals.boilerplate_hit && signals.hover_len < 12) rejectReasons.push("boilerplate_text")
+  if (rejectReasons.length) {
+    return { hint: "reject", reasons: rejectReasons }
+  }
+
+  const reviewReasons: string[] = []
+  if (!signals.has_url) reviewReasons.push("missing_url")
+  if (!signals.has_pubdate) reviewReasons.push("missing_pubdate")
+  if (signals.title_noise_ratio >= 0.45) reviewReasons.push("title_noise_high")
+  if (signals.has_hover && signals.hover_noise_ratio >= 0.55) reviewReasons.push("hover_noise_high")
+  if (signals.source_health_score < 60) reviewReasons.push("source_health_low")
+  if (signals.fallback_used) reviewReasons.push("source_fallback_used")
+  if (signals.attempt_error_count > 0) reviewReasons.push("source_attempt_errors")
+  if (signals.timestamp_confidence === "low") reviewReasons.push("timestamp_low_confidence")
+  if (signals.age_seconds !== null && signals.age_seconds > 7 * 24 * 3600) reviewReasons.push("stale_content")
+  if (signals.cross_source_duplicate_count >= 2) reviewReasons.push("cross_source_duplicate")
+
+  if (reviewReasons.length) {
+    return { hint: "review", reasons: reviewReasons }
+  }
+
+  return { hint: "pass", reasons: [] }
+}
+
+export function evaluateQualityForItems(
+  inputItems: NewsItem[],
+  options: EvaluateQualityOptions,
+): EvaluateQualityResult {
+  const nowMs = options.nowMs ?? Date.now()
+  const sourceContexts = options.sourceContexts || {}
+  const defaultSource = options.defaultSource || "unknown"
+  const attachSignals = options.attachSignals === true
+  const enableHardReject = options.enableHardReject !== false
+
+  const canonicalCount = new Map<string, number>()
+  const canonicalSources = new Map<string, Set<string>>()
+  const sourceByItem = inputItems.map(item => inferSource(item, defaultSource))
+
+  for (let i = 0; i < inputItems.length; i++) {
+    const item = inputItems[i]
+    const source = sourceByItem[i]
+    const key = getCanonicalKey(item)
+    canonicalCount.set(key, (canonicalCount.get(key) || 0) + 1)
+    if (!canonicalSources.has(key)) canonicalSources.set(key, new Set())
+    canonicalSources.get(key)!.add(source)
+  }
+
+  const evaluations: QualityEvaluation[] = []
+  const output: NewsItem[] = []
+  const stats: QualityGateStats = {
+    total_items: inputItems.length,
+    rule_reject_count: 0,
+    review_count: 0,
+    pass_count: 0,
+  }
+
+  for (let i = 0; i < inputItems.length; i++) {
+    const item = inputItems[i]
+    const source = sourceByItem[i]
+    const key = getCanonicalKey(item)
+    const sourceContext: SourceQualityContext = sourceContexts[source] || {
+      source_health_score: 100,
+      fallback_used: false,
+      attempt_error_count: 0,
+      health_status: "healthy",
+    }
+    const sourceDuplicateCount = (canonicalSources.get(key)?.size || 1) - 1
+
+    const qualitySignals = buildSignals(item, {
+      source,
+      sourceProfile: options.sourceProfile,
+      sourceContext,
+      canonicalCount: canonicalCount.get(key) || 1,
+      crossSourceDuplicateCount: Math.max(0, sourceDuplicateCount),
+      nowMs,
+    })
+    const gate = buildGateHint(qualitySignals)
+
+    evaluations.push({
+      item,
+      source,
+      quality_signals: qualitySignals,
+      quality_gate_hint: gate.hint,
+      quality_reasons: gate.reasons,
+    })
+
+    if (gate.hint === "reject") stats.rule_reject_count++
+    if (gate.hint === "review") stats.review_count++
+    if (gate.hint === "pass") stats.pass_count++
+
+    if (gate.hint === "reject" && enableHardReject) {
+      continue
+    }
+
+    if (attachSignals) {
+      output.push({
+        ...item,
+        quality_signals: qualitySignals,
+        quality_gate_hint: gate.hint,
+        quality_reasons: gate.reasons,
+      } as NewsItem)
+    } else {
+      output.push(item)
+    }
+  }
+
+  return {
+    items: output,
+    evaluations,
+    stats,
+  }
+}
+
+export function summarizeQualityBySource(evaluations: QualityEvaluation[]): Record<string, PerSourceQualityStats> {
+  const summary: Record<string, PerSourceQualityStats> = {}
+  for (const evaluation of evaluations) {
+    if (!summary[evaluation.source]) {
+      summary[evaluation.source] = {
+        total_items: 0,
+        rule_reject_count: 0,
+        review_count: 0,
+        pass_count: 0,
+      }
+    }
+    const current = summary[evaluation.source]
+    current.total_items++
+    if (evaluation.quality_gate_hint === "reject") current.rule_reject_count++
+    if (evaluation.quality_gate_hint === "review") current.review_count++
+    if (evaluation.quality_gate_hint === "pass") current.pass_count++
+  }
+  return summary
+}
+
+export function getQualityRubric() {
+  return {
+    quality_schema_version: QUALITY_SCHEMA_VERSION,
+    quality_policy: QUALITY_POLICY,
+    ai_usage_protocol: [
+      "1) 调用 newsnow quality-rubric --json 读取 rubric",
+      "2) 调用 newsnow feed --json --meta --quality-signals 获取候选与监控",
+      "3) 仅对 quality_gate_hint=review 或高风险项做 LLM 判定",
+      "4) 输出 reject/downrank/pass 并在 AI 侧执行门控与降权",
+    ],
+    cli_item_fields: {
+      quality_signals: {
+        title_len: "number",
+        has_url: "boolean",
+        has_pubdate: "boolean",
+        has_hover: "boolean",
+        hover_len: "number",
+        id_stable: "boolean",
+        title_noise_ratio: "number",
+        hover_noise_ratio: "number",
+        low_value_pattern_hit: "boolean",
+        boilerplate_hit: "boolean",
+        source_health_score: "number",
+        fallback_used: "boolean",
+        attempt_error_count: "number",
+        source_profile: "string",
+        age_seconds: "number|null",
+        timestamp_confidence: "none|low|medium|high",
+        dedupe_hit: "boolean",
+        canonical_url: "string|null",
+        cross_source_duplicate_count: "number",
+      },
+      quality_gate_hint: "reject|review|pass",
+      quality_reasons: "string[]",
+    },
+    ai_output_schema: {
+      type: "object",
+      required: ["decision", "reason"],
+      properties: {
+        decision: {
+          type: "string",
+          enum: ["reject", "downrank", "pass"],
+        },
+        reason: { type: "string" },
+        confidence: {
+          type: "number",
+          minimum: 0,
+          maximum: 1,
+        },
+      },
+    },
+  }
 }

--- a/src/source-health.ts
+++ b/src/source-health.ts
@@ -20,6 +20,13 @@ export interface SourceHealth {
   reason: string
 }
 
+export interface SourceQualityContext {
+  source_health_score: number
+  fallback_used: boolean
+  attempt_error_count: number
+  health_status: SourceHealth["status"]
+}
+
 export interface FetchWithFallbackResult {
   requestedSource: string
   usedSource: string
@@ -27,6 +34,19 @@ export interface FetchWithFallbackResult {
   fallbackUsed: boolean
   attempts: SourceAttempt[]
   health: SourceHealth
+}
+
+export function buildSourceQualityContext(
+  health: SourceHealth,
+  attempts: SourceAttempt[],
+  fallbackUsed: boolean,
+): SourceQualityContext {
+  return {
+    source_health_score: health.score,
+    fallback_used: fallbackUsed,
+    attempt_error_count: attempts.filter(a => !a.ok).length,
+    health_status: health.status,
+  }
 }
 
 const SOURCE_FALLBACKS: Record<string, string[]> = {

--- a/src/source-health.ts
+++ b/src/source-health.ts
@@ -1,0 +1,189 @@
+import type { SourceDef } from "./types.js"
+
+export interface FetchWithFallbackOptions {
+  enableFallback?: boolean
+}
+
+export interface SourceAttempt {
+  source: string
+  ok: boolean
+  isArray: boolean
+  itemCount: number
+  durationMs: number
+  usedAsFallback: boolean
+  error?: string
+}
+
+export interface SourceHealth {
+  status: "healthy" | "degraded" | "failed"
+  score: number
+  reason: string
+}
+
+export interface FetchWithFallbackResult {
+  requestedSource: string
+  usedSource: string
+  items: unknown
+  fallbackUsed: boolean
+  attempts: SourceAttempt[]
+  health: SourceHealth
+}
+
+const SOURCE_FALLBACKS: Record<string, string[]> = {
+  "bilibili-ranking": ["bilibili-hot-video", "bilibili-hot-search"],
+  "fastbull": ["fastbull-news", "jin10", "mktnews-flash"],
+  "fastbull-express": ["fastbull-news", "jin10", "mktnews-flash"],
+  "linuxdo": ["v2ex", "github-trending-today", "hackernews"],
+  "linuxdo-hot": ["v2ex-share", "github-trending-today"],
+  "linuxdo-latest": ["v2ex", "hackernews"],
+  "pcbeta-windows": ["pcbeta-windows11"],
+  "producthunt": ["hackernews", "github-trending-today"],
+  "qqvideo-tv-hotsearch": ["iqiyi-hot-ranklist", "bilibili-hot-video"],
+  "smzdm": ["chongbuluo-hot", "kaopu"],
+}
+
+function getItemCount(items: unknown): number {
+  return Array.isArray(items) ? items.length : 0
+}
+
+function getFallbackCandidates(name: string, handlers: SourceDef): string[] {
+  const exact = SOURCE_FALLBACKS[name] || []
+  const prefix = Object.entries(SOURCE_FALLBACKS)
+    .filter(([key]) => key.endsWith("*") && name.startsWith(key.replace(/\*$/, "")))
+    .flatMap(([, values]) => values)
+  const all = [...exact, ...prefix]
+  const uniq = Array.from(new Set(all))
+  return uniq.filter(k => k !== name && typeof handlers[k] === "function")
+}
+
+async function runAttempt(source: string, handler: SourceDef[string], usedAsFallback: boolean): Promise<{ attempt: SourceAttempt; items: unknown }> {
+  const start = Date.now()
+  try {
+    const items = await handler()
+    const durationMs = Date.now() - start
+    const isArray = Array.isArray(items)
+    return {
+      items,
+      attempt: {
+        source,
+        ok: true,
+        isArray,
+        itemCount: getItemCount(items),
+        durationMs,
+        usedAsFallback,
+      },
+    }
+  } catch (error: any) {
+    const durationMs = Date.now() - start
+    return {
+      items: [],
+      attempt: {
+        source,
+        ok: false,
+        isArray: false,
+        itemCount: 0,
+        durationMs,
+        usedAsFallback,
+        error: String(error?.message || error),
+      },
+    }
+  }
+}
+
+function buildHealth(requestedSource: string, usedSource: string, attempts: SourceAttempt[], fallbackUsed: boolean): SourceHealth {
+  const primary = attempts[0]
+  const allFailed = attempts.every(a => !a.ok)
+  if (allFailed) {
+    return {
+      status: "failed",
+      score: 10,
+      reason: `all attempts failed (${requestedSource})`,
+    }
+  }
+
+  let score = 100
+  if (!primary.ok) score -= 55
+  if (primary.ok && !primary.isArray) score -= 35
+  if (primary.ok && primary.isArray && primary.itemCount === 0) score -= 25
+  if (fallbackUsed) score -= 20
+  if (primary.durationMs > 2500) score -= 10
+  score = Math.max(0, Math.min(100, score))
+
+  if (fallbackUsed) {
+    return {
+      status: "degraded",
+      score,
+      reason: `fallback used (${requestedSource} -> ${usedSource})`,
+    }
+  }
+
+  if (!primary.ok || !primary.isArray || primary.itemCount === 0) {
+    return {
+      status: "degraded",
+      score,
+      reason: !primary.ok
+        ? `primary source failed (${requestedSource})`
+        : (!primary.isArray ? `non-array response (${requestedSource})` : `empty result (${requestedSource})`),
+    }
+  }
+
+  return {
+    status: "healthy",
+    score,
+    reason: `primary source ok (${requestedSource})`,
+  }
+}
+
+export async function fetchWithFallback(
+  name: string,
+  handlers: SourceDef,
+  options: FetchWithFallbackOptions = {},
+): Promise<FetchWithFallbackResult> {
+  const enableFallback = options.enableFallback !== false
+  const primaryHandler = handlers[name]
+  if (!primaryHandler) {
+    throw new Error(`Unknown source "${name}"`)
+  }
+
+  const attempts: SourceAttempt[] = []
+  const primary = await runAttempt(name, primaryHandler, false)
+  attempts.push(primary.attempt)
+
+  const primaryUsable = primary.attempt.ok && primary.attempt.isArray && primary.attempt.itemCount > 0
+  if (primaryUsable || !enableFallback) {
+    return {
+      requestedSource: name,
+      usedSource: name,
+      items: primary.items,
+      fallbackUsed: false,
+      attempts,
+      health: buildHealth(name, name, attempts, false),
+    }
+  }
+
+  const candidates = getFallbackCandidates(name, handlers)
+  for (const candidate of candidates) {
+    const fallback = await runAttempt(candidate, handlers[candidate], true)
+    attempts.push(fallback.attempt)
+    const usable = fallback.attempt.ok && fallback.attempt.isArray && fallback.attempt.itemCount > 0
+    if (usable) {
+      return {
+        requestedSource: name,
+        usedSource: candidate,
+        items: fallback.items,
+        fallbackUsed: true,
+        attempts,
+        health: buildHealth(name, candidate, attempts, true),
+      }
+    }
+  }
+
+  return {
+    requestedSource: name,
+    usedSource: name,
+    items: primary.items,
+    fallbackUsed: false,
+    attempts,
+    health: buildHealth(name, name, attempts, false),
+  }
+}

--- a/src/source-profiles.ts
+++ b/src/source-profiles.ts
@@ -1,0 +1,57 @@
+export type SourceProfile = "high-quality" | "trending" | "all"
+
+const HIGH_QUALITY_SOURCES: readonly string[] = [
+  "thepaper",
+  "zaobao",
+  "ithome",
+  "zhihu",
+  "jin10",
+  "mktnews",
+  "mktnews-flash",
+  "cls",
+  "cls-depth",
+  "cls-telegraph",
+  "wallstreetcn",
+  "wallstreetcn-news",
+  "wallstreetcn-quick",
+  "freebuf",
+  "sspai",
+  "hackernews",
+  "github",
+  "github-trending-today",
+  "v2ex",
+  "v2ex-share",
+  "solidot",
+  "ifeng",
+  "cankaoxiaoxi",
+  "kaopu",
+  "pcbeta-windows11",
+]
+
+const TRENDING_SOURCES: readonly string[] = [
+  "weibo",
+  "toutiao",
+  "baidu",
+  "douyin",
+  "bilibili",
+  "bilibili-hot-search",
+  "tieba",
+  "xueqiu",
+  "xueqiu-hotstock",
+  "iqiyi-hot-ranklist",
+  "qqvideo-tv-hotsearch",
+  "douban",
+]
+
+export function isSourceProfile(value: string): value is SourceProfile {
+  return value === "high-quality" || value === "trending" || value === "all"
+}
+
+export function getSourcesByProfile(profile: SourceProfile, allSourceNames: string[]): string[] {
+  const all = Array.from(new Set(allSourceNames)).sort()
+  if (profile === "all") return all
+
+  const table = profile === "trending" ? TRENDING_SOURCES : HIGH_QUALITY_SOURCES
+  const allow = new Set(table)
+  return all.filter(name => allow.has(name))
+}

--- a/src/sources/bilibili.ts
+++ b/src/sources/bilibili.ts
@@ -1,4 +1,3 @@
-import * as cheerio from "cheerio"
 import { myFetch } from "../fetch.js"
 import type { NewsItem, SourceDef } from "../types.js"
 
@@ -17,6 +16,7 @@ interface WapRes {
 
 interface HotVideoRes {
   code: number
+  message?: string
   data: {
     list: {
       bvid: string
@@ -27,12 +27,34 @@ interface HotVideoRes {
       owner: { name: string }
       stat: { view: number; like: number }
     }[]
+  } | null
+}
+
+const BILI_HEADERS = {
+  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+  "Referer": "https://www.bilibili.com/",
+}
+
+function toVideoItems(res?: HotVideoRes): NewsItem[] {
+  if (!res || res.code !== 0 || !res.data || !Array.isArray(res.data.list)) {
+    return []
   }
+  return res.data.list.map(video => ({
+    id: video.bvid,
+    title: video.title,
+    url: `https://www.bilibili.com/video/${video.bvid}`,
+    pubDate: video.pubdate * 1000,
+    extra: {
+      info: `${video.owner.name} · ${formatNumber(video.stat.view)}观看 · ${formatNumber(video.stat.like)}点赞`,
+      hover: video.desc,
+      icon: video.pic,
+    },
+  }))
 }
 
 const hotSearch = async (): Promise<NewsItem[]> => {
   const url = "https://s.search.bilibili.com/main/hotword?limit=30"
-  const res: WapRes = await myFetch(url)
+  const res: WapRes = await myFetch(url, { headers: BILI_HEADERS })
   return res.list.map(k => ({
     id: k.keyword,
     title: k.show_name,
@@ -43,34 +65,24 @@ const hotSearch = async (): Promise<NewsItem[]> => {
 
 const hotVideo = async (): Promise<NewsItem[]> => {
   const url = "https://api.bilibili.com/x/web-interface/popular"
-  const res: HotVideoRes = await myFetch(url)
-  return res.data.list.map(video => ({
-    id: video.bvid,
-    title: video.title,
-    url: `https://www.bilibili.com/video/${video.bvid}`,
-    pubDate: video.pubdate * 1000,
-    extra: {
-      info: `${video.owner.name} · ${formatNumber(video.stat.view)}观看 · ${formatNumber(video.stat.like)}点赞`,
-      hover: video.desc,
-      icon: video.pic,
-    },
-  }))
+  const res: HotVideoRes = await myFetch(url, { headers: BILI_HEADERS })
+  return toVideoItems(res)
 }
 
 const ranking = async (): Promise<NewsItem[]> => {
-  const url = "https://api.bilibili.com/x/web-interface/ranking/v2"
-  const res: HotVideoRes = await myFetch(url)
-  return res.data.list.map(video => ({
-    id: video.bvid,
-    title: video.title,
-    url: `https://www.bilibili.com/video/${video.bvid}`,
-    pubDate: video.pubdate * 1000,
-    extra: {
-      info: `${video.owner.name} · ${formatNumber(video.stat.view)}观看 · ${formatNumber(video.stat.like)}点赞`,
-      hover: video.desc,
-      icon: video.pic,
-    },
-  }))
+  const primaryUrls = [
+    "https://api.bilibili.com/x/web-interface/ranking/v2?rid=0&type=all",
+    "https://api.bilibili.com/x/web-interface/ranking/v2",
+  ]
+
+  for (const url of primaryUrls) {
+    const res: HotVideoRes = await myFetch(url, { headers: BILI_HEADERS })
+    const items = toVideoItems(res)
+    if (items.length) return items
+  }
+
+  // If ranking endpoints are blocked by risk-control, fallback to popular list.
+  return hotVideo()
 }
 
 export default {

--- a/src/sources/bilibili.ts
+++ b/src/sources/bilibili.ts
@@ -76,13 +76,21 @@ const ranking = async (): Promise<NewsItem[]> => {
   ]
 
   for (const url of primaryUrls) {
-    const res: HotVideoRes = await myFetch(url, { headers: BILI_HEADERS })
-    const items = toVideoItems(res)
-    if (items.length) return items
+    try {
+      const res: HotVideoRes = await myFetch(url, { headers: BILI_HEADERS })
+      const items = toVideoItems(res)
+      if (items.length) return items
+    } catch {
+      // Continue to next ranking endpoint.
+    }
   }
 
   // If ranking endpoints are blocked by risk-control, fallback to popular list.
-  return hotVideo()
+  try {
+    return await hotVideo()
+  } catch {
+    return []
+  }
 }
 
 export default {

--- a/src/sources/qqvideo.ts
+++ b/src/sources/qqvideo.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs"
 import { myFetch } from "../fetch.js"
 import type { NewsItem, SourceDef } from "../types.js"
 
@@ -9,6 +8,7 @@ interface CardParams {
 }
 
 interface WapResp {
+  ret?: number
   data: {
     card: {
       children_list: {
@@ -61,13 +61,21 @@ const hotSearch = async (): Promise<NewsItem[]> => {
       },
     },
   })
-  return resp?.data?.card?.children_list?.list?.cards?.map((item) => ({
-    id: item?.id,
-    title: item?.params?.title,
-    url: getQqVideoUrl(item?.id),
-    pubDate: item?.params?.publish_date ?? dayjs().format("YYYY-MM-DD"),
-    extra: { hover: item?.params?.sub_title },
-  }))
+  const cards = resp?.data?.card?.children_list?.list?.cards
+  if (!Array.isArray(cards)) return []
+
+  return cards
+    .filter(item => !!item?.id && !!item?.params?.title)
+    .map((item) => {
+      const parsedTime = item.params?.publish_date ? Date.parse(item.params.publish_date) : NaN
+      return {
+        id: item.id,
+        title: item.params.title,
+        url: getQqVideoUrl(item.id),
+        pubDate: Number.isNaN(parsedTime) ? undefined : parsedTime,
+        extra: { hover: item.params.sub_title },
+      }
+    })
 }
 
 export default { "qqvideo-tv-hotsearch": hotSearch } satisfies SourceDef

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -67,6 +67,17 @@ describe("cli", () => {
     const err = await new Response(proc.stderr).text()
     expect(err).toContain("Unknown source")
   })
+
+  test("missing value for profile fails fast", async () => {
+    const proc = Bun.spawn(["bun", "src/cli.ts", "list", "--profile", "--json"], {
+      cwd: import.meta.dir + "/..",
+      stderr: "pipe",
+    })
+    const err = await new Response(proc.stderr).text()
+    const code = await proc.exited
+    expect(code).not.toBe(0)
+    expect(err).toContain("Missing value for --profile")
+  })
 })
 
 describe("fetch source", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -78,6 +78,17 @@ describe("cli", () => {
     expect(code).not.toBe(0)
     expect(err).toContain("Missing value for --profile")
   })
+
+  test("quality-rubric command returns schema json", async () => {
+    const proc = Bun.spawn(["bun", "src/cli.ts", "quality-rubric", "--json"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+    })
+    const output = await new Response(proc.stdout).text()
+    const parsed = JSON.parse(output)
+    expect(parsed.quality_schema_version).toBeDefined()
+    expect(parsed.ai_output_schema?.properties?.decision?.enum).toContain("downrank")
+  })
 })
 
 describe("fetch source", () => {
@@ -89,4 +100,21 @@ describe("fetch source", () => {
     expect(items[0]).toHaveProperty("id")
     expect(items[0]).toHaveProperty("url")
   }, 15000)
+
+  test("hackernews quality-signals json includes monitor fields", async () => {
+    const proc = Bun.spawn(["bun", "src/cli.ts", "hackernews", "--json", "--quality-signals"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+    })
+    const output = await new Response(proc.stdout).text()
+    const parsed = JSON.parse(output)
+    expect(parsed.quality_schema_version).toBeDefined()
+    expect(parsed.quality_monitor).toBeDefined()
+    expect(Array.isArray(parsed.items)).toBe(true)
+    if (parsed.items.length > 0) {
+      expect(parsed.items[0].quality_signals).toBeDefined()
+      expect(parsed.items[0].quality_gate_hint).toBeDefined()
+      expect(Array.isArray(parsed.items[0].quality_reasons)).toBe(true)
+    }
+  }, 30000)
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -25,8 +25,8 @@ describe("registry", () => {
 })
 
 describe("cli", () => {
-  test("list command outputs sources", async () => {
-    const proc = Bun.spawn(["bun", "src/cli.ts", "list", "--json"], {
+  test("list command outputs all sources with profile all", async () => {
+    const proc = Bun.spawn(["bun", "src/cli.ts", "list", "--json", "--profile", "all"], {
       cwd: import.meta.dir + "/..",
       stdout: "pipe",
     })
@@ -35,6 +35,19 @@ describe("cli", () => {
     expect(Array.isArray(names)).toBe(true)
     expect(names.length).toBeGreaterThan(40)
     expect(names).toContain("hackernews")
+  })
+
+  test("list defaults to high-quality profile", async () => {
+    const proc = Bun.spawn(["bun", "src/cli.ts", "list", "--json"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+    })
+    const output = await new Response(proc.stdout).text()
+    const names = JSON.parse(output)
+    expect(Array.isArray(names)).toBe(true)
+    expect(names.length).toBeGreaterThan(10)
+    expect(names).toContain("thepaper")
+    expect(names).not.toContain("weibo")
   })
 
   test("help command works", async () => {

--- a/test/enhance.test.ts
+++ b/test/enhance.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { enhanceNewsItems, extractSummaryFromHtml } from "../src/enhance.js"
+
+describe("extractSummaryFromHtml", () => {
+  test("prefers meta description", () => {
+    const html = `
+      <html>
+        <head>
+          <meta name="description" content="This is a concise article summary from metadata." />
+        </head>
+        <body><article><p>Body text</p></article></body>
+      </html>
+    `
+    const summary = extractSummaryFromHtml(html)
+    expect(summary).toContain("concise article summary")
+  })
+
+  test("falls back to article paragraph text", () => {
+    const html = `
+      <html>
+        <body>
+          <article>
+            <p>This paragraph has enough useful details for an extracted summary.</p>
+            <p>Second paragraph.</p>
+          </article>
+        </body>
+      </html>
+    `
+    const summary = extractSummaryFromHtml(html)
+    expect(summary).toContain("useful details")
+  })
+
+  test("ignores generic site-level meta summary", () => {
+    const html = `
+      <html>
+        <head>
+          <meta name="description" content="某新闻网是最活跃的互联网平台，致力于提供权威发布。" />
+        </head>
+        <body>
+          <article>
+            <p>This is the actual article summary from body paragraphs with concrete details.</p>
+          </article>
+        </body>
+      </html>
+    `
+    const summary = extractSummaryFromHtml(html)
+    expect(summary).toContain("actual article summary")
+  })
+
+  test("rejects footer-like low-value summary text", () => {
+    const html = `
+      <html>
+        <body>
+          <p>登录 Android版 iPhone版 沪ICP备14003370号 沪公网安备31010602000299号</p>
+        </body>
+      </html>
+    `
+    const summary = extractSummaryFromHtml(html)
+    expect(summary).toBeUndefined()
+  })
+})
+
+describe("enhanceNewsItems", () => {
+  test("is no-op when list is empty", async () => {
+    const result = await enhanceNewsItems([], { limit: 5 })
+    expect(result.items).toEqual([])
+    expect(result.stats.attempted).toBe(0)
+    expect(result.stats.enhanced).toBe(0)
+  })
+})

--- a/test/enhance.test.ts
+++ b/test/enhance.test.ts
@@ -67,4 +67,13 @@ describe("enhanceNewsItems", () => {
     expect(result.stats.attempted).toBe(0)
     expect(result.stats.enhanced).toBe(0)
   })
+
+  test("counts skipped items when enhance limit is zero", async () => {
+    const result = await enhanceNewsItems([
+      { id: "1", title: "a", url: "https://example.com/a" },
+      { id: "2", title: "b", url: "https://example.com/b" },
+    ], { limit: 0 })
+    expect(result.stats.attempted).toBe(0)
+    expect(result.stats.skipped).toBe(2)
+  })
 })

--- a/test/quality.test.ts
+++ b/test/quality.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "bun:test"
+import { normalizeNewsItems } from "../src/quality.js"
+
+describe("normalizeNewsItems", () => {
+  test("handles non-array input", () => {
+    const { items, stats } = normalizeNewsItems(null)
+    expect(items).toEqual([])
+    expect(stats.nonArrayInput).toBe(true)
+  })
+
+  test("dedupes by url and title", () => {
+    const { items, stats } = normalizeNewsItems([
+      { id: "1", title: "Hello World", url: "https://example.com/a#x" },
+      { id: "2", title: "Hello World", url: "https://example.com/b" },
+      { id: "3", title: "Another", url: "https://example.com/a" },
+    ])
+    expect(items.length).toBe(1)
+    expect(stats.droppedDuplicate).toBe(2)
+  })
+
+  test("filters obviously low-quality titles", () => {
+    const { items, stats } = normalizeNewsItems([
+      { id: "1", title: "广告", url: "https://example.com/ad" },
+      { id: "2", title: "AI", url: "https://example.com/ai" },
+      { id: "3", title: "-", url: "https://example.com/dash" },
+    ])
+    expect(items.length).toBe(1)
+    expect(items[0].title).toBe("AI")
+    expect(stats.droppedLowQuality).toBe(2)
+  })
+})

--- a/test/quality.test.ts
+++ b/test/quality.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "bun:test"
-import { normalizeNewsItems } from "../src/quality.js"
+import {
+  evaluateQualityForItems,
+  getQualityRubric,
+  normalizeNewsItems,
+  QUALITY_SCHEMA_VERSION,
+} from "../src/quality.js"
 
 describe("normalizeNewsItems", () => {
   test("handles non-array input", () => {
@@ -27,5 +32,61 @@ describe("normalizeNewsItems", () => {
     expect(items.length).toBe(1)
     expect(items[0].title).toBe("AI")
     expect(stats.droppedLowQuality).toBe(2)
+  })
+})
+
+describe("evaluateQualityForItems", () => {
+  test("attaches signals and gate hints", () => {
+    const result = evaluateQualityForItems([
+      {
+        id: "abc",
+        title: "OpenAI released a new research update",
+        url: "https://example.com/a",
+        pubDate: Date.now(),
+        extra: { hover: "Model eval and benchmark details." },
+      },
+    ], {
+      sourceProfile: "high-quality",
+      sourceContexts: {
+        sourceA: {
+          source_health_score: 88,
+          fallback_used: false,
+          attempt_error_count: 0,
+          health_status: "healthy",
+        },
+      },
+      defaultSource: "sourceA",
+      attachSignals: true,
+    })
+
+    expect(result.items.length).toBe(1)
+    const item = result.items[0] as any
+    expect(item.quality_signals).toBeDefined()
+    expect(item.quality_gate_hint).toBeDefined()
+    expect(Array.isArray(item.quality_reasons)).toBe(true)
+  })
+
+  test("hard rejects low value titles", () => {
+    const result = evaluateQualityForItems([
+      { id: "1", title: "广告", url: "https://example.com/ad" },
+      { id: "2", title: "值得阅读的技术文章", url: "https://example.com/ok" },
+    ], {
+      sourceProfile: "high-quality",
+      defaultSource: "demo",
+      enableHardReject: true,
+    })
+
+    expect(result.stats.rule_reject_count).toBe(1)
+    expect(result.items.length).toBe(1)
+    expect(result.items[0].title).toContain("值得阅读")
+  })
+})
+
+describe("quality rubric", () => {
+  test("returns fixed schema", () => {
+    const rubric = getQualityRubric() as any
+    expect(rubric.quality_schema_version).toBe(QUALITY_SCHEMA_VERSION)
+    expect(rubric.quality_policy).toBeDefined()
+    expect(rubric.ai_output_schema?.properties?.decision?.enum).toContain("downrank")
   })
 })

--- a/test/source-health.test.ts
+++ b/test/source-health.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import type { SourceDef } from "../src/types.js"
+import { fetchWithFallback } from "../src/source-health.js"
+
+describe("fetchWithFallback", () => {
+  test("uses fallback when primary fails", async () => {
+    const handlers: SourceDef = {
+      linuxdo: async () => {
+        throw new Error("403 Forbidden")
+      },
+      v2ex: async () => [{ id: "1", title: "ok", url: "https://example.com/1" }],
+      "github-trending-today": async () => [{ id: "2", title: "ok2", url: "https://example.com/2" }],
+      hackernews: async () => [{ id: "3", title: "ok3", url: "https://example.com/3" }],
+    }
+    const result = await fetchWithFallback("linuxdo", handlers)
+    expect(result.fallbackUsed).toBe(true)
+    expect(result.usedSource).not.toBe("linuxdo")
+    expect(Array.isArray(result.items)).toBe(true)
+    expect(result.health.status).toBe("degraded")
+  })
+
+  test("keeps primary when it is healthy", async () => {
+    const handlers: SourceDef = {
+      demo: async () => [{ id: "1", title: "ok", url: "https://example.com/1" }],
+    }
+    const result = await fetchWithFallback("demo", handlers)
+    expect(result.fallbackUsed).toBe(false)
+    expect(result.usedSource).toBe("demo")
+    expect(result.health.status).toBe("healthy")
+  })
+
+  test("respects no-fallback mode", async () => {
+    const handlers: SourceDef = {
+      linuxdo: async () => {
+        throw new Error("blocked")
+      },
+      v2ex: async () => [{ id: "1", title: "ok", url: "https://example.com/1" }],
+      "github-trending-today": async () => [{ id: "2", title: "ok2", url: "https://example.com/2" }],
+      hackernews: async () => [{ id: "3", title: "ok3", url: "https://example.com/3" }],
+    }
+    const result = await fetchWithFallback("linuxdo", handlers, { enableFallback: false })
+    expect(result.fallbackUsed).toBe(false)
+    expect(result.usedSource).toBe("linuxdo")
+    expect(result.health.status).toBe("failed")
+  })
+})

--- a/test/source-health.test.ts
+++ b/test/source-health.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { SourceDef } from "../src/types.js"
-import { fetchWithFallback } from "../src/source-health.js"
+import { buildSourceQualityContext, fetchWithFallback } from "../src/source-health.js"
 
 describe("fetchWithFallback", () => {
   test("uses fallback when primary fails", async () => {
@@ -42,5 +42,20 @@ describe("fetchWithFallback", () => {
     expect(result.fallbackUsed).toBe(false)
     expect(result.usedSource).toBe("linuxdo")
     expect(result.health.status).toBe("failed")
+  })
+
+  test("maps source quality context fields", () => {
+    const ctx = buildSourceQualityContext(
+      { status: "degraded", score: 42, reason: "fallback used" },
+      [
+        { source: "a", ok: false, isArray: false, itemCount: 0, durationMs: 100, usedAsFallback: false, error: "blocked" },
+        { source: "b", ok: true, isArray: true, itemCount: 2, durationMs: 120, usedAsFallback: true },
+      ],
+      true,
+    )
+    expect(ctx.source_health_score).toBe(42)
+    expect(ctx.fallback_used).toBe(true)
+    expect(ctx.attempt_error_count).toBe(1)
+    expect(ctx.health_status).toBe("degraded")
   })
 })

--- a/test/source-profiles.test.ts
+++ b/test/source-profiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { getSourcesByProfile, isSourceProfile } from "../src/source-profiles.js"
+
+describe("source profiles", () => {
+  const all = [
+    "weibo",
+    "thepaper",
+    "zhihu",
+    "hackernews",
+    "linuxdo",
+    "toutiao",
+    "jin10",
+  ]
+
+  test("validates profile names", () => {
+    expect(isSourceProfile("high-quality")).toBe(true)
+    expect(isSourceProfile("trending")).toBe(true)
+    expect(isSourceProfile("all")).toBe(true)
+    expect(isSourceProfile("unknown")).toBe(false)
+  })
+
+  test("returns all sources for all profile", () => {
+    expect(getSourcesByProfile("all", all)).toEqual([...all].sort())
+  })
+
+  test("high-quality profile filters out trending-only sources", () => {
+    const list = getSourcesByProfile("high-quality", all)
+    expect(list).toContain("thepaper")
+    expect(list).toContain("jin10")
+    expect(list).not.toContain("weibo")
+    expect(list).not.toContain("toutiao")
+  })
+
+  test("trending profile contains trending sources", () => {
+    const list = getSourcesByProfile("trending", all)
+    expect(list).toContain("weibo")
+    expect(list).toContain("toutiao")
+    expect(list).not.toContain("jin10")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
       "#/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## 方案目标
将 `newsnow` 从规则过滤器升级为 AI 可判定的质量监控前置层：CLI 输出结构化质量信号与门控建议，AI 侧完成语义终判（`reject/downrank/pass`）。

## 本次实现
### 1. 新增命令
- `newsnow quality-rubric --json`
- 返回固定 rubric、字段定义与 AI 判分输出 schema

### 2. 新增参数
- `--quality-signals`（仅 JSON 输出生效）
- 适用于 `newsnow <source>` 与 `newsnow feed`

### 3. 顶层 JSON 字段扩展
当开启 `--quality-signals` 或 `--meta` 时输出：
- `quality_schema_version`
- `quality_monitor`
- `quality_policy`

### 4. item 级字段扩展
- `quality_signals`
- `quality_gate_hint`（`reject|review|pass`）
- `quality_reasons`

### 5. 质量信号覆盖
已覆盖以下信号族：
- 结构完整性：`title_len`、`has_url`、`has_pubdate`、`has_hover`、`hover_len`、`id_stable`
- 可读性：`title_noise_ratio`、`hover_noise_ratio`、`low_value_pattern_hit`、`boilerplate_hit`
- 来源可靠性：`source_health_score`、`fallback_used`、`attempt_error_count`、`source_profile`
- 新鲜度：`age_seconds`、`timestamp_confidence`
- 去重聚合：`dedupe_hit`、`canonical_url`、`cross_source_duplicate_count`

### 6. 门控策略
- CLI 硬门控：空标题、极短标题、明显低价值文本、非数组异常
- CLI 预建议：`quality_gate_hint=reject|review|pass`
- AI 终判：仅依赖 rubric + quality signals，不在 CLI 内调用模型 API

### 7. 在线监控指标
`quality_monitor` 提供运行级与来源级统计：
- 运行级：`total_items`、`rule_reject_count`、`review_count`、`pass_count`、`degraded_source_count`、`fallback_source_count`、`avg_source_health_score`
- 来源级：`source`、`item_count`、`rule_reject_rate`、`health_status`、`fallback_used`
- 风险提示：`quality_alerts`

## 关键文件变更
- `src/quality.ts`：新增质量信号计算、门控建议、rubric 输出
- `src/source-health.ts`：新增来源质量上下文字段映射
- `src/cli.ts`：新增 `quality-rubric`、`--quality-signals`、`quality_monitor` 聚合输出
- `README.md`、`skills/newsnow/SKILL.md`：新增 AI 工作流与新字段说明

## 测试与验证
- `bun run build` 通过
- `bun test test/*.test.ts` 通过（31 pass, 0 fail）
- 新增/更新测试覆盖：
  - `test/quality.test.ts`
  - `test/source-health.test.ts`
  - `test/cli.test.ts`

## 兼容性说明
- 未开启 `--quality-signals` 且未开启 `--meta` 时，保持原有 JSON 输出形态（仅 items）
- 不新增模型配置项，不引入 API Key 依赖
- AI 判分不可用时，仍可依赖 CLI 规则门控继续输出


## 流程图

```mermaid
flowchart TD
  A["newsnow quality-rubric --json"] --> B["AI 读取固定 rubric 与输出 schema"]
  C["newsnow feed --json --meta --quality-signals"] --> D["CLI 输出 items + quality_signals + quality_monitor"]
  D --> E{"quality_gate_hint"}
  E -->|"reject"| F["CLI 规则拦截"]
  E -->|"review"| G["AI 执行语义判分"]
  E -->|"pass"| H["直接进入候选集"]
  G --> I{"AI decision"}
  I -->|"reject"| J["剔除"]
  I -->|"downrank"| K["降权保留"]
  I -->|"pass"| L["正常排序"]
  H --> L
  K --> L
  L --> M["输出高质量内容给上游 AI"]
```
